### PR TITLE
Import division from future and sort all imports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,10 @@ This ensures that:
  * the print statement cannot be used
  * the / operator means true division
 
+Note that this can be automated by running:
+
+`isort <your module>.py`
+
 The `e3` namespace
 ------------------
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,18 +17,21 @@ All entry points must instanciate `e3.main.Main` to parse their options.
 
 Exceptions raised by `e3` should derived from `e3.error.E3Error`.
 
-All import used in `e3` should be _absolute imports_. To force this, we add at
-the beginning of each `e3` module:
+All `e3` Python 2 code is converted to Python 3 using `2to3`. To minimize
+the differences between the two versions, we're adding the following
+import statements at the beginning of each module:
 
 ```python
 from __future__ import absolute_import
-```
-
-All `e3` Python 2 code is converted to Python 3 using `2to3`, to simply the writing of tests also import the Python 3 print function with:
-
-```python
+from __future__ import division
 from __future__ import print_function
 ```
+
+This ensures that:
+
+ * all imports are absolute imports
+ * the print statement cannot be used
+ * the / operator means true division
 
 The `e3` namespace
 ------------------

--- a/e3/anod/buildspace.py
+++ b/e3/anod/buildspace.py
@@ -1,23 +1,22 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
-import os
-import sys
 import logging
 import logging.handlers
-import yaml
+import os
+import sys
 from datetime import datetime as dt
-from yaml.reader import ReaderError
-from yaml.parser import ParserError
+
 import e3.error
 import e3.log
 import e3.os.process
-from e3.hash import sha1
+import yaml
+from e3.anod.error import AnodError
 from e3.anod.fingerprint import Fingerprint
 from e3.anod.status import ReturnValue
-from e3.anod.error import AnodError
 from e3.fs import mkdir, rm
-
+from e3.hash import sha1
+from yaml.parser import ParserError
+from yaml.reader import ReaderError
 
 logger = e3.log.getLogger('buildspace')
 

--- a/e3/anod/context.py
+++ b/e3/anod/context.py
@@ -1,18 +1,17 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
-from e3.collection.dag import DAG
+from e3.anod.action import (Build, BuildOrInstall, Checkout, CreateSource,
+                            CreateSourceOrDownload, Decision, DownloadBinary,
+                            DownloadSource, GetSource, Install,
+                            InstallSource, Root, Test, UploadBinaryComponent,
+                            UploadComponent, UploadSourceComponent)
 from e3.anod.deps import Dependency
 from e3.anod.error import AnodError
+from e3.anod.package import UnmanagedSourceBuilder
+from e3.anod.spec import has_primitive
+from e3.collection.dag import DAG
 from e3.env import BaseEnv
 from e3.error import E3Error
-from e3.anod.spec import has_primitive
-from e3.anod.package import UnmanagedSourceBuilder
-from e3.anod.action import (Root, InstallSource, CreateSource, Checkout,
-                            DownloadSource, GetSource, Build, Test, Install,
-                            DownloadBinary, Decision, BuildOrInstall,
-                            UploadComponent, UploadBinaryComponent,
-                            UploadSourceComponent,
-                            CreateSourceOrDownload)
 
 
 class SchedulingError(E3Error):

--- a/e3/anod/deps.py
+++ b/e3/anod/deps.py
@@ -1,7 +1,7 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import collections
+
 import e3.anod.error
 from e3.env import BaseEnv
 

--- a/e3/anod/driver.py
+++ b/e3/anod/driver.py
@@ -1,16 +1,13 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
-from functools import wraps
 import os
 import sys
-
-from e3.error import E3Error
-
-from e3.anod.spec import AnodError, has_primitive
+from functools import wraps
 
 import e3.log
 import e3.store
+from e3.anod.spec import AnodError, has_primitive
+from e3.error import E3Error
 
 logger = e3.log.getLogger('e3.anod.driver')
 

--- a/e3/anod/error.py
+++ b/e3/anod/error.py
@@ -1,4 +1,5 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
 import e3.error
 
 

--- a/e3/anod/fingerprint.py
+++ b/e3/anod/fingerprint.py
@@ -5,15 +5,15 @@ and allow Anod to detect changes in these states. This is mainly used to
 decide if a given action has been done and is up-to-date.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
+import hashlib
+import os
 from collections import OrderedDict
 
 from e3.anod.error import AnodError
 from e3.env import Env
 from e3.hash import sha1
-
-import os
-import hashlib
 
 FINGERPRINT_VERSION = '1.1'
 # This value should be bumped each time computation of the fingerprint changes.

--- a/e3/anod/helper.py
+++ b/e3/anod/helper.py
@@ -1,21 +1,19 @@
 """Helpers classes and functions for ANOD."""
 
-from __future__ import absolute_import
-import e3.log
-from e3.anod.spec import parse_command
-from e3.anod.error import AnodError
-from e3.fs import find
-from e3.fs import rm
-from e3.os.fs import unixpath
-from e3.yaml import custom_repr
-
-from StringIO import StringIO
+from __future__ import absolute_import, division, print_function
 
 import io
 import os
 import re
-import yaml
+from StringIO import StringIO
 
+import e3.log
+import yaml
+from e3.anod.error import AnodError
+from e3.anod.spec import parse_command
+from e3.fs import find, rm
+from e3.os.fs import unixpath
+from e3.yaml import custom_repr
 
 log = e3.log.getLogger('anod.helpers')
 

--- a/e3/anod/loader.py
+++ b/e3/anod/loader.py
@@ -1,15 +1,14 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import imp
 import inspect
-
-from e3.anod.error import SandBoxError
-from e3.fs import ls
-import e3.hash
-import e3.log
 import os
 import sys
+
+import e3.hash
+import e3.log
+from e3.anod.error import SandBoxError
+from e3.fs import ls
 
 logger = e3.log.getLogger('anod.loader')
 

--- a/e3/anod/package.py
+++ b/e3/anod/package.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import e3.anod.error
 import e3.diff

--- a/e3/anod/sandbox/action.py
+++ b/e3/anod/sandbox/action.py
@@ -1,13 +1,12 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import abc
 import argparse
 
 import e3.log
-from e3.fs import mkdir
 from e3.anod.sandbox import SandBox, SandBoxError
 from e3.anod.sandbox.main import main
+from e3.fs import mkdir
 from e3.vcs.git import GitRepository
 
 

--- a/e3/anod/sandbox/main.py
+++ b/e3/anod/sandbox/main.py
@@ -1,8 +1,7 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
-import stevedore
 import e3.log
+import stevedore
 from e3.main import Main
 
 

--- a/e3/anod/sandbox/scripts.py
+++ b/e3/anod/sandbox/scripts.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 from e3.anod.error import AnodError
 from e3.main import Main

--- a/e3/anod/spec.py
+++ b/e3/anod/spec.py
@@ -1,19 +1,18 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import os
 from collections import OrderedDict
 
-from e3.anod.error import AnodError, ShellError
-from e3.anod.status import ReturnValue
-from e3.yaml import load_with_config
 import e3.anod.deps
 import e3.anod.package
-import yaml
 import e3.env
 import e3.log
 import e3.os.process
 import e3.text
+import yaml
+from e3.anod.error import AnodError, ShellError
+from e3.anod.status import ReturnValue
+from e3.yaml import load_with_config
 
 # CURRENT API version
 __version__ = '1.4'

--- a/e3/anod/status.py
+++ b/e3/anod/status.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 from enum import Enum
 

--- a/e3/archive.py
+++ b/e3/archive.py
@@ -1,13 +1,12 @@
 """Support for reading and writing tar and zip archives."""
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
-from contextlib import closing
 import fnmatch
 import os
 import subprocess
 import sys
 import tempfile
+from contextlib import closing
 
 import e3
 import e3.error

--- a/e3/binarydata/elf.py
+++ b/e3/binarydata/elf.py
@@ -1,12 +1,12 @@
 """Basic ELF reader."""
 
-from __future__ import absolute_import
-from __future__ import print_function
-from e3.binarydata import UChar, UInt16, BinaryData, UInt32, \
-    CharStr, Address, Offset, UIntMax, Field, StructType, String, \
-    FieldArray, FieldNullTerminatedArray, \
-    BinaryFileBuffer
-from os.path import dirname, join, isfile
+from __future__ import absolute_import, division, print_function
+
+from os.path import dirname, isfile, join
+
+from e3.binarydata import (Address, BinaryData, BinaryFileBuffer, CharStr,
+                           Field, FieldArray, FieldNullTerminatedArray, Offset,
+                           String, StructType, UChar, UInt16, UInt32, UIntMax)
 
 E_TYPE_STR = {
     0: 'No file type',

--- a/e3/binarydata/macho.py
+++ b/e3/binarydata/macho.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import os
 import re

--- a/e3/collection/dag.py
+++ b/e3/collection/dag.py
@@ -1,7 +1,7 @@
 """Implementation of Direct Acyclic Graphs."""
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 from e3.error import E3Error
 
 

--- a/e3/decorator.py
+++ b/e3/decorator.py
@@ -2,8 +2,7 @@
 
 to enable/disable a function, to memoize a function results...
 """
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 from functools import partial
 

--- a/e3/diff.py
+++ b/e3/diff.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import fnmatch
 import re

--- a/e3/electrolyt/hosts.py
+++ b/e3/electrolyt/hosts.py
@@ -1,8 +1,6 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import yaml
-
 from e3.env import BaseEnv
 
 

--- a/e3/electrolyt/plans.py
+++ b/e3/electrolyt/plans.py
@@ -1,11 +1,10 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
+import ast
 import imp
 import inspect
-import ast
-
 from functools import partial
+
 from e3.env import BaseEnv
 
 

--- a/e3/env.py
+++ b/e3/env.py
@@ -3,8 +3,7 @@
 This package provide a class called Env used to store global
 information. Env is a singleton so there is in fact only one instance.
 """
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import abc
 import os

--- a/e3/error.py
+++ b/e3/error.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 
 class E3Error(Exception):

--- a/e3/event/backends/base.py
+++ b/e3/event/backends/base.py
@@ -1,13 +1,11 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import abc
 import uuid
 
-from e3.error import E3Error
-
 import e3.env
 import e3.hash
+from e3.error import E3Error
 
 
 class Event(object):

--- a/e3/event/backends/smtp.py
+++ b/e3/event/backends/smtp.py
@@ -1,15 +1,14 @@
-from __future__ import absolute_import
-import mimetypes
-import json
+from __future__ import absolute_import, division, print_function
 
+import json
+import mimetypes
 from email import encoders
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
-from email.utils import make_msgid, formatdate
-
-from e3.event.backends.base import Event, EventManager
+from email.utils import formatdate, make_msgid
 
 import e3.net.smtp
+from e3.event.backends.base import Event, EventManager
 
 
 class SMTPEvent(Event):

--- a/e3/fs.py
+++ b/e3/fs.py
@@ -1,7 +1,6 @@
 """High-Level file manipulation."""
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import fnmatch
 import glob

--- a/e3/hash.py
+++ b/e3/hash.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import hashlib
 import os

--- a/e3/log.py
+++ b/e3/log.py
@@ -1,11 +1,11 @@
 """Extensions to the standard Python logging system."""
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import logging
+import re
 import sys
 import time
-import re
+
 from colorama import Fore, Style
 from tqdm import tqdm
 

--- a/e3/main.py
+++ b/e3/main.py
@@ -20,12 +20,13 @@ will also be provided::
     --host       to set the host
     --target     to set the target
 """
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import logging
 import os
-import sys
 import signal
+import sys
+
 import e3
 import e3.log
 from e3.env import Env

--- a/e3/mainloop.py
+++ b/e3/mainloop.py
@@ -19,8 +19,7 @@ Note also that from the user point view there is no parallelism to handle.
 The two user defined function run_job and collect_result are called
 sequentially.
 """
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import argparse
 import os

--- a/e3/net/http.py
+++ b/e3/net/http.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 
 import cgi
@@ -103,7 +104,7 @@ class HTTPSession(object):
                 path = os.path.join(dest, filename)
                 logger.info('downloading %s size=%s', path, content_length)
 
-                expected_size = content_length / self.CHUNK_SIZE
+                expected_size = content_length // self.CHUNK_SIZE
                 with open(path, 'wb') as fd:
                     for chunk in e3.log.progress_bar(
                             response.iter_content(self.CHUNK_SIZE),

--- a/e3/net/http.py
+++ b/e3/net/http.py
@@ -1,19 +1,17 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import cgi
 import contextlib
 import os
 import socket
-import requests
-import requests.adapters
-import requests.packages.urllib3.exceptions
-from requests.packages.urllib3.util import Retry
-import requests.exceptions
 import tempfile
 
 import e3.log
+import requests
+import requests.adapters
+import requests.exceptions
+import requests.packages.urllib3.exceptions
+from requests.packages.urllib3.util import Retry
 
 logger = e3.log.getLogger('net.http')
 

--- a/e3/net/smtp.py
+++ b/e3/net/smtp.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import os
 import smtplib

--- a/e3/os/fs.py
+++ b/e3/os/fs.py
@@ -4,18 +4,15 @@ All function here should be platform indepenent, should not involve globbing or
 logging (unless in case of unexpected failure).
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
+import collections
 import itertools
 import os
 import re
 import shutil
 import stat
 import sys
-
-import collections
 
 import e3
 import e3.error

--- a/e3/os/fs.py
+++ b/e3/os/fs.py
@@ -5,8 +5,8 @@ logging (unless in case of unexpected failure).
 """
 
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
-
 
 import itertools
 import os
@@ -191,10 +191,10 @@ def df(path, full=False):
         used = ((st.f_blocks - st.f_bfree) * st.f_frsize)
     if full:
         return _ntuple_diskusage(
-            total / (1024 * 1024),
-            used / (1024 * 1024),
-            free / (1024 * 1024))
-    return free / (1024 * 1024)
+            total // (1024 * 1024),
+            used // (1024 * 1024),
+            free // (1024 * 1024))
+    return free // (1024 * 1024)
 
 
 def __safe_unlink_func():

--- a/e3/os/platform.py
+++ b/e3/os/platform.py
@@ -1,10 +1,9 @@
 """Provides function to detect platform specific information."""
-from __future__ import absolute_import
-from __future__ import print_function
-from platform import uname as platform_uname
-from collections import namedtuple
+from __future__ import absolute_import, division, print_function
 
 import re
+from collections import namedtuple
+from platform import uname as platform_uname
 
 import e3.log
 from e3.platform_db import get_knowledge_base

--- a/e3/os/process.py
+++ b/e3/os/process.py
@@ -5,20 +5,20 @@ processes in blocking or non blocking mode, redirection of its stdout,
 stderr and stdin. It also provides some helpers to check the process
 status
 """
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import errno
 import itertools
 import logging
 import os
 import re
-import subprocess
 import signal
+import subprocess
 import sys
 import time
 
-import e3.log
 import e3.env
+import e3.log
 from e3.os.fs import which
 
 logger = e3.log.getLogger('os.process')

--- a/e3/os/timezone.py
+++ b/e3/os/timezone.py
@@ -1,11 +1,10 @@
 """Return the current timezone offset."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
+import sys
+from datetime import datetime
 
 from dateutil.tz import gettz
-from datetime import datetime
-import sys
 
 
 def timezone():

--- a/e3/os/timezone.py
+++ b/e3/os/timezone.py
@@ -1,5 +1,6 @@
 """Return the current timezone offset."""
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 
 from dateutil.tz import gettz
@@ -29,7 +30,7 @@ def timezone():
         win_tz_pt = pointer(win_tz)
         windll.kernel32.GetTimeZoneInformation(win_tz_pt)
         result = win_tz.Bias
-        result = - int(result) / 60
+        result = - int(result) // 60
     else:
         # Note that in case timezone cannot be computed then
         # utcoffset can return None.
@@ -37,6 +38,6 @@ def timezone():
         if result is None:
             result = 0  # defensive code
         else:
-            result = result.total_seconds() / 3600
+            result = result.total_seconds() // 3600
 
     return float(result)

--- a/e3/os/windows/fs.py
+++ b/e3/os/windows/fs.py
@@ -1,16 +1,16 @@
-from __future__ import absolute_import
-from __future__ import print_function
-from e3.os.windows.native_api import (IOStatusBlock, UnicodeString,
-                                      NTException, NT, FileInfo,
-                                      ObjectAttributes, Share, Access,
-                                      Status, OpenOptions, FileAttribute)
-from ctypes import (pointer, create_unicode_buffer, create_string_buffer,
-                    c_wchar_p, sizeof)
-from ctypes.wintypes import HANDLE
+from __future__ import absolute_import, division, print_function
+
 import os
 import struct
-import e3.log
+from ctypes import (c_wchar_p, create_string_buffer,
+                    create_unicode_buffer, pointer, sizeof)
+from ctypes.wintypes import HANDLE
 
+import e3.log
+from e3.os.windows.native_api import (NT, Access, FileAttribute, FileInfo,
+                                      IOStatusBlock, NTException,
+                                      ObjectAttributes, OpenOptions, Share,
+                                      Status, UnicodeString)
 
 logger = e3.log.getLogger('os.windows.fs')
 

--- a/e3/os/windows/native_api.py
+++ b/e3/os/windows/native_api.py
@@ -1,16 +1,15 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
-from e3.error import E3Error
-from ctypes import (Structure, create_unicode_buffer, pointer, cast, c_wchar_p,
-                    sizeof, POINTER)
-from ctypes.wintypes import (USHORT, LPWSTR, DWORD, LONG, BOOLEAN, INT, BOOL,
-                             LARGE_INTEGER, LPVOID, ULONG, HANDLE)
-from datetime import datetime
 import ctypes
 import sys
 import time
+from ctypes import (POINTER, Structure, c_wchar_p, cast,
+                    create_unicode_buffer, pointer, sizeof)
+from ctypes.wintypes import (BOOL, BOOLEAN, DWORD, HANDLE, INT, LARGE_INTEGER,
+                             LONG, LPVOID, LPWSTR, ULONG, USHORT)
+from datetime import datetime
+
+from e3.error import E3Error
 
 NTSTATUS = LONG
 

--- a/e3/os/windows/native_api.py
+++ b/e3/os/windows/native_api.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 
 from e3.error import E3Error
@@ -160,13 +161,13 @@ class FileTime(Structure):
     def as_datetime(self):
         try:
             return datetime.fromtimestamp(
-                self.filetime / 10000000 - 11644473600)
+                self.filetime // 10000000 - 11644473600)
         except ValueError as err:
             raise ValueError("filetime '%s' failed with %s" % (
                              self.filetime, err))
 
     def __str__(self):
-        return str(time.ctime(self.filetime / 10000000 - 11644473600))
+        return str(time.ctime(self.filetime // 10000000 - 11644473600))
 
 
 class FileInfo(object):

--- a/e3/os/windows/process.py
+++ b/e3/os/windows/process.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 
 def process_exit_code(handle):

--- a/e3/platform.py
+++ b/e3/platform.py
@@ -1,12 +1,10 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import collections
 
 import e3.os
 import e3.os.platform
 from e3.platform_db import get_knowledge_base
-
 
 KNOWLEDGE_BASE = get_knowledge_base()
 

--- a/e3/platform_db/knowledge_base.py
+++ b/e3/platform_db/knowledge_base.py
@@ -4,6 +4,7 @@ Note that even if this is pure data this is not stored as a yaml. This
 knowledge base is very often read and the cost of parsing the data can
 be significant in some context.
 """
+from __future__ import absolute_import, division, print_function
 
 CPU_INFO = {
     'aarch64': {'endian': 'little', 'bits': 64},

--- a/e3/store/backends/base.py
+++ b/e3/store/backends/base.py
@@ -1,12 +1,10 @@
-from __future__ import absolute_import
-from __future__ import print_function
-from collections import namedtuple
+from __future__ import absolute_import, division, print_function
 
 import abc
+from collections import namedtuple
 
 import e3.log
 from e3.error import E3Error
-
 
 logger = e3.log.getLogger('store')
 

--- a/e3/store/backends/http_simple_store.py
+++ b/e3/store/backends/http_simple_store.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
-
+from __future__ import absolute_import, division, print_function
 
 import e3.hash
 import e3.log

--- a/e3/store/cache/backends/base.py
+++ b/e3/store/cache/backends/base.py
@@ -1,9 +1,7 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import abc
 import time
-
 
 DEFAULT_TIMEOUT = 3600 * 24
 

--- a/e3/store/cache/backends/filecache.py
+++ b/e3/store/cache/backends/filecache.py
@@ -1,20 +1,18 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import errno
-
-try:
-    import cPickle as pickle
-except ImportError:  # defensive code
-    import pickle
-
 import os
 import tempfile
 import time
 
 import e3.log
 from e3.fs import mkdir, rm
-from e3.store.cache.backends.base import Cache, DEFAULT_TIMEOUT
+from e3.store.cache.backends.base import DEFAULT_TIMEOUT, Cache
+
+try:
+    import cPickle as pickle
+except ImportError:  # defensive code
+    import pickle
 
 
 class FileCache(Cache):

--- a/e3/sys.py
+++ b/e3/sys.py
@@ -1,11 +1,11 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import ast
-from enum import Enum
 import os
 import re
 import sys
+
+from enum import Enum
 
 
 class RewriteNodeError(Exception):

--- a/e3/text.py
+++ b/e3/text.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import re
 

--- a/e3/vcs/git.py
+++ b/e3/vcs/git.py
@@ -13,13 +13,12 @@ Example::
             authors.append(commit['email'])
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
-from subprocess import PIPE
-import sys
-import tempfile
+from __future__ import absolute_import, division, print_function
 
 import itertools
+import sys
+import tempfile
+from subprocess import PIPE
 
 import e3.error
 import e3.fs

--- a/e3/yaml.py
+++ b/e3/yaml.py
@@ -1,17 +1,16 @@
 """Modification of the yaml loader for E3."""
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
-
-from collections import OrderedDict
-import e3.log
-from e3.text import format_with_dict
 import os
 import re
 import sys
+from collections import OrderedDict
+
+import e3.log
 import yaml
 import yaml.constructor
 import yaml.parser
+from e3.text import format_with_dict
 
 try:
     from yaml import CLoader as Loader

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[isort]
+balanced_wrapping = True
+add_imports =
+    from __future__ import absolute_import
+    from __future__ import division
+    from __future__ import print_function

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,13 @@
-from __future__ import absolute_import
-import pytest
+from __future__ import absolute_import, division, print_function
+
+import logging
 import tempfile
+
+import e3.log
+import pytest
 from e3.env import Env
 from e3.fs import rm
 from e3.os.fs import cd
-import e3.log
-import logging
 
 # Activate full debug logs
 e3.log.activate(level=logging.DEBUG, e3_debug=True)

--- a/tests/fix-coverage-paths.py
+++ b/tests/fix-coverage-paths.py
@@ -3,9 +3,12 @@
 # show only paths corresponding to the real source files
 # From https://github.com/danilobellini/pytest-doctest-custom/
 
-from coverage.data import PathAliases, CoverageData
+from __future__ import absolute_import, division, print_function
+
 import os
 import sys
+
+from coverage.data import CoverageData, PathAliases
 
 
 def fix_paths(site_pkg_dir, cov_data_file):

--- a/tests/gen-cov-config.py
+++ b/tests/gen-cov-config.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 
-from e3.env import Env
+from __future__ import absolute_import, division, print_function
 
 import os
 import sys
+
+from e3.env import Env
 
 
 def main(coverage_rc):

--- a/tests/tests_e3/anod/fingerprint_test.py
+++ b/tests/tests_e3/anod/fingerprint_test.py
@@ -1,12 +1,11 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
+import os
+
+import pytest
 from e3.anod.error import AnodError
 from e3.anod.fingerprint import Fingerprint
 from e3.env import Env
-
-import pytest
-import os
 
 
 def test_fingerprint():

--- a/tests/tests_e3/anod/helper_test.py
+++ b/tests/tests_e3/anod/helper_test.py
@@ -1,10 +1,9 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import os
 
 from e3.anod.driver import AnodDriver
-from e3.anod.helper import Make, Configure, text_replace
+from e3.anod.helper import Configure, Make, text_replace
 from e3.anod.sandbox import SandBox
 from e3.anod.spec import Anod
 

--- a/tests/tests_e3/anod/loader_test.py
+++ b/tests/tests_e3/anod/loader_test.py
@@ -1,12 +1,10 @@
-from __future__ import absolute_import
-from __future__ import print_function
-
-from e3.anod.loader import AnodSpecRepository
-from e3.anod.error import SandBoxError
-
+from __future__ import absolute_import, division, print_function
 
 import os
+
 import pytest
+from e3.anod.error import SandBoxError
+from e3.anod.loader import AnodSpecRepository
 
 
 class TestLoader(object):

--- a/tests/tests_e3/anod/spec_test.py
+++ b/tests/tests_e3/anod/spec_test.py
@@ -1,13 +1,12 @@
-from __future__ import absolute_import
-from __future__ import print_function
-
-from e3.anod.driver import AnodDriver
-from e3.anod.error import AnodError
-from e3.anod.spec import Anod, has_primitive
-from e3.anod.sandbox import SandBox
+from __future__ import absolute_import, division, print_function
 
 import os
+
 import pytest
+from e3.anod.driver import AnodDriver
+from e3.anod.error import AnodError
+from e3.anod.sandbox import SandBox
+from e3.anod.spec import Anod, has_primitive
 
 
 def test_simple_spec():

--- a/tests/tests_e3/anod/test_buildspace.py
+++ b/tests/tests_e3/anod/test_buildspace.py
@@ -1,11 +1,13 @@
-from e3.anod.status import ReturnValue
-from e3.anod.buildspace import BuildSpace
-from e3.anod.fingerprint import Fingerprint
-from e3.os.fs import touch
+from __future__ import absolute_import, division, print_function
 
 import datetime
 import os
+
 import pytest
+from e3.anod.buildspace import BuildSpace
+from e3.anod.fingerprint import Fingerprint
+from e3.anod.status import ReturnValue
+from e3.os.fs import touch
 
 
 def test_reset():

--- a/tests/tests_e3/anod/test_driver.py
+++ b/tests/tests_e3/anod/test_driver.py
@@ -1,11 +1,10 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
+import os
 
 import e3.anod.driver
 import e3.anod.sandbox
 import e3.anod.spec
-
-import os
 import pytest
 
 

--- a/tests/tests_e3/anod/test_sandbox.py
+++ b/tests/tests_e3/anod/test_sandbox.py
@@ -1,12 +1,11 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import os
 
+import e3.anod.sandbox
 import e3.env
 import e3.fs
 import e3.os.process
-import e3.anod.sandbox
 
 
 def test_deploy_sandbox():

--- a/tests/tests_e3/archive/main_test.py
+++ b/tests/tests_e3/archive/main_test.py
@@ -1,9 +1,11 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
+import os
+
 import e3.archive
 import e3.fs
 import e3.log
 import e3.os.fs
-import os
 import pytest
 
 

--- a/tests/tests_e3/binarydata/main_test.py
+++ b/tests/tests_e3/binarydata/main_test.py
@@ -1,9 +1,9 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
 import sys
 
-import pytest
-
 import e3.os.process
+import pytest
 from e3.binarydata import BinaryFileBuffer
 from e3.binarydata.elf import Elf, ElfMagic
 

--- a/tests/tests_e3/collection/dag/main_test.py
+++ b/tests/tests_e3/collection/dag/main_test.py
@@ -1,6 +1,7 @@
-from __future__ import absolute_import
-from e3.collection.dag import DAG, DAGIterator, DAGError
+from __future__ import absolute_import, division, print_function
+
 import pytest
+from e3.collection.dag import DAG, DAGError, DAGIterator
 
 
 def test_simple_dag():

--- a/tests/tests_e3/decorator/main_test.py
+++ b/tests/tests_e3/decorator/main_test.py
@@ -1,9 +1,9 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
 from random import random
 
-import pytest
-
 import e3.decorator
+import pytest
 
 
 def test_memoize():

--- a/tests/tests_e3/diff/main_test.py
+++ b/tests/tests_e3/diff/main_test.py
@@ -1,7 +1,9 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
+import os
+
 import e3.diff
 import e3.fs
-import os
 import pytest
 
 

--- a/tests/tests_e3/env/main_test.py
+++ b/tests/tests_e3/env/main_test.py
@@ -1,13 +1,13 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
 import os
 import sys
 
-import pytest
-
 import e3.env
 import e3.fs
-import e3.platform
 import e3.os.process
+import e3.platform
+import pytest
 
 
 def test_autodetect():

--- a/tests/tests_e3/event/main_test.py
+++ b/tests/tests_e3/event/main_test.py
@@ -1,14 +1,16 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
 import contextlib
 import email
 import json
-import mock
 import os
 
 import e3.archive
 import e3.event
 import e3.fs
 import e3.os.fs
+
+import mock
 
 
 def test_smtp_event():

--- a/tests/tests_e3/fs/main_test.py
+++ b/tests/tests_e3/fs/main_test.py
@@ -1,11 +1,13 @@
-from __future__ import absolute_import
-import e3.hash
-import e3.fs
-import e3.diff
-import e3.os.fs
+from __future__ import absolute_import, division, print_function
+
 import os
-import pytest
 import sys
+
+import e3.diff
+import e3.fs
+import e3.hash
+import e3.os.fs
+import pytest
 
 
 def test_cp():

--- a/tests/tests_e3/hash/main_test.py
+++ b/tests/tests_e3/hash/main_test.py
@@ -1,6 +1,7 @@
-import pytest
+from __future__ import absolute_import, division, print_function
 
 import e3.hash
+import pytest
 
 
 def test_hash():

--- a/tests/tests_e3/log/main_test.py
+++ b/tests/tests_e3/log/main_test.py
@@ -1,8 +1,9 @@
-from __future__ import absolute_import
-import dateutil.parser
+from __future__ import absolute_import, division, print_function
+
 import datetime
 import sys
 
+import dateutil.parser
 import e3.log
 import e3.os.process
 

--- a/tests/tests_e3/main/main_test.py
+++ b/tests/tests_e3/main/main_test.py
@@ -1,4 +1,5 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
 import e3.env
 import e3.os.process
 

--- a/tests/tests_e3/mainloop/main_test.py
+++ b/tests/tests_e3/mainloop/main_test.py
@@ -1,11 +1,12 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
 import logging
 import sys
 
 import e3.collection.dag
 import e3.mainloop
-import e3.os.process
 import e3.os.fs
+import e3.os.process
 
 
 def run_job(job_data, job_info):

--- a/tests/tests_e3/net/smtp/main_test.py
+++ b/tests/tests_e3/net/smtp/main_test.py
@@ -1,7 +1,10 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
 import mock
-import e3.net.smtp
 import smtplib
+
+import e3.net.smtp
+
 
 def test_sendmail():
     from_addr = 'e3@example.net'

--- a/tests/tests_e3/os/fs/main_test.py
+++ b/tests/tests_e3/os/fs/main_test.py
@@ -1,12 +1,12 @@
-from __future__ import absolute_import
-import os
-import tempfile
-import sys
+from __future__ import absolute_import, division, print_function
 
-import pytest
+import os
+import sys
+import tempfile
 
 import e3.fs
 import e3.os.fs
+import pytest
 
 
 @pytest.mark.xfail(sys.platform == 'win32',

--- a/tests/tests_e3/os/process/main_test.py
+++ b/tests/tests_e3/os/process/main_test.py
@@ -1,11 +1,13 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
+import os
+import sys
+import time
+
 import e3.fs
 import e3.os.fs
 import e3.os.process
-import os
 import pytest
-import sys
-import time
 
 
 def test_run_shebang():

--- a/tests/tests_e3/os/windows/fs/main_test.py
+++ b/tests/tests_e3/os/windows/fs/main_test.py
@@ -1,15 +1,13 @@
-from __future__ import absolute_import
-
-from e3.os.fs import touch
-from e3.fs import mkdir
-from e3.fs import rm
+from __future__ import absolute_import, division, print_function
 
 import contextlib
-from datetime import datetime, timedelta
 import os
-import pytest
 import sys
+from datetime import datetime, timedelta
 
+import pytest
+from e3.fs import mkdir, rm
+from e3.os.fs import touch
 
 if sys.platform == 'win32':
     from e3.os.windows.fs import NTFile

--- a/tests/tests_e3/platform/main_test.py
+++ b/tests/tests_e3/platform/main_test.py
@@ -1,9 +1,8 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
-import pytest
 import e3.env
 import e3.platform
+import pytest
 
 
 def test_platform():

--- a/tests/tests_e3/store/main_test.py
+++ b/tests/tests_e3/store/main_test.py
@@ -1,10 +1,9 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
+import os
 
 import httpretty
 import httpretty.core
-import os
-
 from e3.store.backends.http_simple_store import HTTPSimpleStore
 
 

--- a/tests/tests_e3/sys/main_test.py
+++ b/tests/tests_e3/sys/main_test.py
@@ -1,16 +1,15 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import ast
 import os
-import pytest
 import sys
 
 import e3.fs
 import e3.os.fs
-from e3.sys import RewriteImportNodeTransformer, RewriteImportRule, \
-    RewriteNodeError
 import e3.sys
+import pytest
+from e3.sys import (RewriteImportNodeTransformer,
+                    RewriteImportRule, RewriteNodeError)
 
 
 def test_filtering_import():

--- a/tests/tests_e3/system/main_test.py
+++ b/tests/tests_e3/system/main_test.py
@@ -1,4 +1,5 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
 import e3.os.process
 import e3.sys
 

--- a/tests/tests_e3/timezone/main_test.py
+++ b/tests/tests_e3/timezone/main_test.py
@@ -1,4 +1,5 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
 import e3.os.timezone
 
 

--- a/tests/tests_e3/yaml/main_test.py
+++ b/tests/tests_e3/yaml/main_test.py
@@ -1,13 +1,15 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
+import e3.log
+import e3.yaml
+import pytest
+import yaml
+
 try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
 
-import pytest
-import yaml
-import e3.yaml
-import e3.log
 
 
 @pytest.mark.parametrize('config,expected', [

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands=
 [testenv:checkstyle]
 basepython = python
 deps =
-      pycodestyle>=2.0.0
+      pycodestyle>=2.0.0,!=2.1.0
       pyflakes>=1.2.3
       pydocstyle>=1.0.0
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -31,10 +31,12 @@ deps =
       pycodestyle>=2.0.0,!=2.1.0
       pyflakes>=1.2.3
       pydocstyle>=1.0.0
+      isort
 commands =
         pycodestyle {envsitepackagesdir}/e3
         pyflakes {envsitepackagesdir}/e3
         pydocstyle {envsitepackagesdir}/e3
+        isort --check-only -rc {envsitepackagesdir}/e3
 
 [testenv:security]
 deps =


### PR DESCRIPTION
Use isort to automatically add:

`    from __future__ import absolute_import`
`    from __future__ import division`
`    from __future__ import print_function`

in each e3 modules.

See #14 and #15 