### PR TITLE
increase test coverage e3.fs to 76% and e3.net.smtp to 93%

### DIFF
--- a/e3/net/smtp.py
+++ b/e3/net/smtp.py
@@ -55,7 +55,8 @@ def sendmail(from_email, to_emails, mail_as_string, smtp_servers,
     def system_sendmail():
         """Run the system sendmail."""
         if system_sendmail_fallback:
-            for sendmail_bin in ('/usr/lib/sendmail', '/usr/sbin/sendmail'):
+            for sendmail_bin in ('/usr/lib/sendmail',
+                                 '/usr/sbin/sendmail'):  # all: no cover
                 if os.path.exists(sendmail_bin):
                     p = e3.os.process.Run(
                         [sendmail_bin] + to_emails,

--- a/tests/tests_e3/fs/main_test.py
+++ b/tests/tests_e3/fs/main_test.py
@@ -54,6 +54,14 @@ def test_cp():
     assert os.path.exists(os.path.join(dest3, 'a1'))
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason='test using symlink')
+def test_cp_symplink():
+    e3.os.fs.touch('c')
+    os.symlink('c', 'c_sym')
+    e3.fs.cp('c_sym', 'd', preserve_symlinks=True)
+    assert os.path.islink('d')
+
+
 def test_echo():
     dest_file = 'echo_test'
     e3.fs.echo_to_file(dest_file, 'foo')
@@ -107,6 +115,15 @@ def test_tree_state():
     e3.os.fs.touch('toto')
     state4 = e3.fs.get_filetree_state(current_dir)
     assert state4 != state3
+    hidden = os.path.join(current_dir, '.h')
+    e3.fs.mkdir(hidden)
+    state5 = e3.fs.get_filetree_state(current_dir)
+    assert state5 == state4
+    e3.os.fs.touch('.toto')
+    state6 = e3.fs.get_filetree_state(current_dir)
+    assert state6 == state5
+    state6 = e3.fs.get_filetree_state('toto')
+    assert isinstance(state6, str)
 
 
 @pytest.mark.skipif(sys.platform == 'win32', reason='test using symlink')

--- a/tests/tests_e3/net/smtp/main_test.py
+++ b/tests/tests_e3/net/smtp/main_test.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import mock
 import e3.net.smtp
-
+import smtplib
 
 def test_sendmail():
     from_addr = 'e3@example.net'
@@ -21,3 +21,45 @@ def test_sendmail():
             from_addr,
             to_addresses,
             msg_as_string)
+
+def test_sendmail_onerror():
+    from_addr = 'e3@example.net'
+    to_addresses = ['info@example.net', 'info@example.com']
+    msg_as_string = 'test mail content'
+    msg_size_exceed = "A"*1200
+    result = e3.net.smtp.sendmail(
+        from_addr,
+        to_addresses,
+        msg_size_exceed,
+        ['smtp.localhost'],
+        max_size=8/1024)
+    assert result is False
+
+    with mock.patch('smtplib.SMTP') as mock_smtp:
+        mock_smtp.side_effect = smtplib.SMTPException()
+        result = e3.net.smtp.sendmail(
+            from_addr,
+            to_addresses,
+            msg_as_string,
+            ['smtp.localhost'])
+        assert result is False
+
+    with mock.patch('smtplib.SMTP') as mock_smtp:
+        smtp_mock = mock_smtp.return_value
+        smtp_mock.sendmail.side_effect = smtplib.SMTPException()
+        result = e3.net.smtp.sendmail(
+            from_addr,
+            to_addresses,
+            msg_as_string,
+            ['smtp.localhost'])
+        assert result is False
+
+    with mock.patch('smtplib.SMTP') as mock_smtp:
+        smtp_mock = mock_smtp.return_value
+        smtp_mock.sendmail.return_value = {}
+        result = e3.net.smtp.sendmail(
+            from_addr,
+            to_addresses,
+            msg_as_string,
+            ['smtp.localhost'])
+        assert result is True


### PR DESCRIPTION
**tests e3.fs**
- added hidden files and unicode tests
- added copy symlink test

**tests e3.net.smtp**
- added different exceptions return from the mocked SMTP object
- added max size test
- added mail sent successfully scenario

**e3.net.smtp**
- added #all: no coverage of the system sendmail binaries