### PR TITLE
Do not require netifaces on Solaris and AIX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,9 @@ install_requires = [
 
 extras_require = {}
 
-for p in ('win32', 'darwin', 'linux', 'linux2'):
+for p in ('darwin', 'linux', 'linux2', 'win32'):
     platform_string = ":sys_platform=='%s'" % p
-    extras_require[platform_string] = ['psutil']
+    extras_require[platform_string] = ['netifaces', 'psutil']
     if p in ('linux', 'linux2'):
         extras_require[platform_string].append('ld')
 


### PR DESCRIPTION
This package is only regularly tested on macOS, Linux, and Windows.