### PR TITLE
Add support Ctrl-C interruption in e3.job.scheduler

### DIFF
--- a/e3/os/process.py
+++ b/e3/os/process.py
@@ -496,9 +496,16 @@ class Run(object):
         else:
             return None
 
-    def kill(self):
-        """Kill the process."""
-        self.internal.kill()
+    def kill(self, recursive=True):
+        """Kill the process.
+
+        :param recursive: if True, try to kill the complete process tree
+        :type recursive: bool
+        """
+        if recursive:
+            kill_process_tree(self.internal)
+        else:
+            self.internal.kill()
 
     def interrupt(self):
         """Send SIGINT CTRL_C_EVENT to the process."""


### PR DESCRIPTION
* add recursive parameter to Run.kill.
* when interrupt is called on a job mark set attribute interrupted
  to True.
* for ProcessJob ensure that proc_handle is set before the end of
  the process to allow interrupt and in case the job is interrupted
  perform a recursive kill.
* in Scheduler add parameter job_timeout that define the maximum amount
  of time a job can run.
* in Scheduler handle Ctrl-C nicely (try to kill all active jobs and
  call collect for them before reraising the exception)