### PR TITLE
Use E3Error exception as a message container

### DIFF
--- a/e3/anod/sandbox/__init__.py
+++ b/e3/anod/sandbox/__init__.py
@@ -6,7 +6,7 @@ from pkg_resources import get_distribution
 from e3.env import Env
 from e3.fs import mkdir, rm
 
-import e3.error
+from e3.anod.error import SandBoxError
 import e3.log
 import e3.os.process
 
@@ -18,10 +18,6 @@ from e3.os.fs import chmod
 from e3.anod.buildspace import BuildSpace
 
 logger = e3.log.getLogger('sandbox')
-
-
-class SandBoxError(e3.error.E3Error):
-    pass
 
 
 class SandBox(object):

--- a/e3/error.py
+++ b/e3/error.py
@@ -7,18 +7,43 @@ class E3Error(Exception):
     def __init__(self, message, origin=None):
         """Initialize an E3Error.
 
+        E3Error can store several messages and thus be used to propagate them.
+
         :param message: the exception message
-        :type message: str
+        :type message: str | list[str]
         :param origin: the name of the function, class, or module having raised
             the exception
         :type origin: str
         """
         super(E3Error, self).__init__(message, origin)
         self.origin = origin
-        self.message = message
+        self.messages = []
+        if message is not None:
+            if isinstance(message, unicode) or isinstance(message, str):
+                self.messages.append(message)
+            else:
+                self.messages.extend(message)
+
+    def __iadd__(self, other):
+        """Add messages to the current instance.
+
+        :param other: a message or an E3Error instance
+        :type other: str | list[str] | E3Error
+        """
+        if isinstance(other, E3Error):
+            self.messages.extend(other.messages)
+        elif isinstance(other, unicode) or isinstance(other, str):
+            self.messages.append(other)
+        else:
+            self.messages.extend(other)
+        return self
 
     def __str__(self):
-        if self.origin:
-            return '%s: %s\n' % (self.origin, self.message)
+        if self.messages:
+            error_msg = self.messages[-1]
         else:
-            return self.message
+            error_msg = self.__class__.__name__
+        if self.origin:
+            return '%s: %s\n' % (self.origin, error_msg)
+        else:
+            return error_msg

--- a/e3/os/process.py
+++ b/e3/os/process.py
@@ -266,7 +266,11 @@ class Run(object):
                 return cmd_line
 
             with open(prog) as f:
-                header = f.read()[0:2]
+                try:
+                    header = f.read()[0:2]
+                except UnicodeDecodeError:  # py3-only
+                    # unknown header - cannot decode the first two bytes
+                    return cmd_line
                 if header != "#!":
                     # Unknown header
                     return cmd_line

--- a/tests/coverage/base.rc
+++ b/tests/coverage/base.rc
@@ -5,6 +5,12 @@ branch = False
 [report]
 fail_under = 60
 # ideally should be around 90, work in progress
+exclude_lines =
+    all: no cover
+    defensive code
+    # + <os>-only and <os>: no cover
+    # + py2-only or py3-only
+
 
 [html]
 title = e3 coverage report

--- a/tests/coverage/darwin.rc
+++ b/tests/coverage/darwin.rc
@@ -2,15 +2,3 @@
 omit =
     */os/windows/*
     */os/unix/constant.py
-
-[report]
-exclude_lines =
-    unix: no cover
-    darwin: no cover
-    all: no cover
-    defensive code
-    linux-only
-    windows-only
-    bsd-only
-    aix-only
-    solaris-only

--- a/tests/coverage/linux.rc
+++ b/tests/coverage/linux.rc
@@ -2,15 +2,3 @@
 omit =
     */os/windows/*
     */os/unix/constant.py
-
-[report]
-exclude_lines =
-    unix: no cover
-    linux: no cover
-    all: no cover
-    defensive code
-    windows-only
-    darwin-only
-    bsd-only
-    aix-only
-    solaris-only

--- a/tests/coverage/windows.rc
+++ b/tests/coverage/windows.rc
@@ -1,14 +1,3 @@
 [run]
 omit =
     */os/unix/*
-
-[report]
-exclude_lines =
-    windows: no cover
-    all: no cover
-    defensive code
-    linux-only
-    darwin-only
-    bsd-only
-    aix-only
-    solaris-only

--- a/tests/gen-cov-config.py
+++ b/tests/gen-cov-config.py
@@ -7,16 +7,47 @@ import sys
 
 from e3.env import Env
 
+try:
+    from ConfigParser import ConfigParser
+except ImportError:  # py3-only
+    from configparser import ConfigParser
+
 
 def main(coverage_rc):
     os_name = Env().build.os.name
     test_dir = os.path.abspath(os.path.dirname(__file__))
+
+    config = ConfigParser()
+    base_conf, target_conf = ((
+        os.path.join(test_dir, 'coverage', '%s.rc' % name)
+        for name in ('base', os_name)))
+
     with open(coverage_rc, 'w') as dest:
-        for source in ((
-            os.path.join(test_dir, 'coverage', '%s.rc' % name)
-                for name in ('base', os_name))):
-            with open(source) as s:
-                dest.write(s.read())
+        config.read(base_conf)
+        config.read(target_conf)
+
+        # exclude lines is built with: base.rc config
+        exclude_lines = config.get('report', 'exclude_lines').splitlines()
+
+        # add all <os>-only patterns
+        exclude_lines += [
+            '%s-only' % o
+            for o in ('darwin', 'linux', 'solaris', 'windows', 'bsd', 'aix')
+            if o != os_name]
+        # exclude this specific os
+        exclude_lines.append('%s: no cover' % os_name)
+
+        # special case for unix
+        if os_name != 'windows':
+            exclude_lines.append('unix: no cover')
+
+        if os.path.basename(sys.executable).startswith('python3'):
+            exclude_lines.append('py2-only')
+        else:
+            exclude_lines.append('py3-only')
+
+        config.set('report', 'exclude_lines', '\n'.join(exclude_lines))
+        config.write(dest)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is used by Anod.shell to create a minimal log in case of
failure.

Add corresponding tests.