### PR TITLE
e3.fs.rm can't remove symlink to directory

### DIFF
--- a/e3/fs.py
+++ b/e3/fs.py
@@ -386,7 +386,9 @@ def rm(path, recursive=False, glob=True):
             if sys.platform == 'win32':  # unix: no cover
                 f = unicode(f)
 
-            if recursive and os.path.isdir(f):
+            # Note: shutil.rmtree requires its argument to be an actual
+            # directory, not a symbolic link to a directory
+            if recursive and os.path.isdir(f) and not os.path.islink(f):
                 shutil.rmtree(f, onerror=onerror)
             else:
                 e3.os.fs.force_remove_file(f)

--- a/tests/tests_e3/fs/main_test.py
+++ b/tests/tests_e3/fs/main_test.py
@@ -298,6 +298,14 @@ def test_rm_list():
     assert not os.path.exists('b')
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason='test using symlink')
+def test_rm_symlink_to_dir():
+    e3.fs.mkdir('a')
+    os.symlink('a', 'b')
+    e3.fs.rm('b', recursive=True)
+    assert not os.path.exists('b')
+
+
 def test_safe_copy():
     """sync_tree should replace directory by files and fix permissions."""
     # Check that a directory in the target dir is replaced by a file when


### PR DESCRIPTION
Prevent symlink to a directory from being passed to shutil.rmtree