### PR TITLE
Set umask 0022 before running chmod tests

### DIFF
--- a/tests/tests_e3/os/fs/main_test.py
+++ b/tests/tests_e3/os/fs/main_test.py
@@ -23,6 +23,7 @@ def test_cd():
 @pytest.mark.xfail(sys.platform == 'win32',
                    reason='not completely supported on windows')
 def test_chmod():
+    os.umask(0o022)
     e3.os.fs.touch('a')
 
     def check_mode(filename, mode):


### PR DESCRIPTION
To have reliable results we should not depend on external umask
setting. Setting os.umask(0022) makes the test reliable even when
the user umask is different.