### PR TITLE
Requests > 2.6.1 breaks urllib3's Retry functionality

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_requires = [
     'colorama',
     'pyyaml',
     'python-dateutil',
-    'requests',
+    'requests<=2.6.1',
     'requests_toolbelt',
     'tqdm',
     'stevedore>1.20.0']


### PR DESCRIPTION
Using lib requests <= 2.6.1 because later version  breaks urllib3's Retry functionality