### PR TITLE
Test fix: Remove unused line in exec command

### DIFF
--- a/tests/tests_e3/anod/test_sandbox.py
+++ b/tests/tests_e3/anod/test_sandbox.py
@@ -328,7 +328,6 @@ def test_anodtest(git_specs_dir, e3fake_git_dir):
     with open(conf_dir, 'w') as conf_fd:
         conf_fd.write(git_repo_entry)
     command = ['e3-sandbox', '-v', 'exec',
-               '--spec-git-url', git_specs_dir,
                '--plan', plan_file,
                sandbox_dir]
     p = e3.os.process.Run(command)


### PR DESCRIPTION
without `--create-sandbox` flag `--spec-git-url` is not used