### PR TITLE
Add ability to support priority in scheduler

### DIFF
--- a/e3/job/scheduler.py
+++ b/e3/job/scheduler.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import heapq
 import time
-from collections import deque
 from datetime import datetime
 from Queue import Empty, Queue
 
@@ -73,7 +73,7 @@ class Scheduler(object):
 
         # Create the queues
         for name, max_token in queues.iteritems():
-            self.queues[name] = deque()
+            self.queues[name] = []
             self.tokens[name] = max_token
             self.n_tokens += max_token
 
@@ -183,7 +183,7 @@ class Scheduler(object):
                     self.collect(job)
                     self.dag_iterator.leave(uid)
                 else:
-                    self.queues[job.queue_name].append(job)
+                    heapq.heappush(self.queues[job.queue_name], job)
                     self.queued_jobs += 1
         except StopIteration:
             self.all_jobs_queued = True
@@ -196,7 +196,7 @@ class Scheduler(object):
         for name in self.queues:
             q = self.queues[name]
             while q and q[0].tokens <= self.tokens[name]:
-                next_job = q.popleft()
+                next_job = heapq.heappop(q)
                 next_job.start(slot=self.slots.pop())
                 self.tokens[name] -= next_job.tokens
                 self.queued_jobs -= 1
@@ -246,7 +246,7 @@ class Scheduler(object):
 
                 if self.collect(job):
                     # Requeue when needed
-                    self.queues[job.queue_name].append(job)
+                    heapq.heappush(self.queues[job.queue_name], job)
                     self.queued_jobs += 1
                 else:
                     # Mark the job as completed

--- a/tests/tests_e3/job/scheduling_test.py
+++ b/tests/tests_e3/job/scheduling_test.py
@@ -14,6 +14,9 @@ class NopJob(Job):
     def run(self):
         pass
 
+    def __cmp__(self, other):
+        return cmp(self.uid, other.uid)
+
 
 class SleepJob(ProcessJob):
 
@@ -32,6 +35,22 @@ class TestScheduler(object):
         s = Scheduler(Scheduler.simple_provider(NopJob), tokens=2)
         s.run(dag)
         assert s.max_active_jobs == 2
+
+    def test_ordering(self):
+        """Test that jobs are ordered correctly."""
+        results = []
+
+        def collect(job):
+            results.append(job.uid)
+
+        dag = DAG()
+        dag.add_vertex('3')
+        dag.add_vertex('0')
+        dag.add_vertex('1')
+        s = Scheduler(Scheduler.simple_provider(NopJob), tokens=1,
+                      collect=collect)
+        s.run(dag)
+        assert tuple(results) == ('0', '1', '3')
 
     def test_minimal_run2(self):
         """Test with two interdependent jobs."""


### PR DESCRIPTION
If the Job class support comparison, job preference will be from
lower to highest value. Thus notion of priority can be introduced
by implementing the __cmp__ builtin function in a Job subclass