### PR TITLE
Add ability to support priority in scheduler

### DIFF
--- a/e3/job/__init__.py
+++ b/e3/job/__init__.py
@@ -37,6 +37,12 @@ class Job(object):
     :ivar tokens: number of tokens (i.e: resources) consumed during the job
         execution
     :vartype: int
+    :ivar index: global index indicating the order in which jobs have been
+        created. The index is used to implement the default ordering function
+        needed to sort Jobs. In the context of ``e3.job.scheduler.Scheduler``
+        this means that by default jobs that are created first will have a
+        higher priority.
+    :vartype: int
     """
 
     __metaclass__ = abc.ABCMeta
@@ -72,18 +78,35 @@ class Job(object):
             Job.index_counter += 1
 
     def __lt__(self, other):
+        """Compare two jobs.
+
+        This method can be reimplemented in order to provider other
+        priority systems.
+
+        :param other: another Job
+        :type other: Job
+        :return: True if self has a strictly higher priority than other
+        :rtype: bool
+        """
         return self.index < other.index
 
     def record_start_time(self):
+        """Log the starting time of a job."""
         with self._lock:
             self.__start_time = datetime.now()
 
     def record_stop_time(self):
+        """Log the stopping time of a job."""
         with self._lock:
             self.__stop_time = datetime.now()
 
     @property
     def timing_info(self):
+        """Retrieve some job's timing information.
+
+        :return: a JobTimingInfo object
+        :rtype: JobTimingInfo
+        """
         with self._lock:
             start = self.__start_time
             stop = self.__stop_time

--- a/e3/job/__init__.py
+++ b/e3/job/__init__.py
@@ -41,6 +41,7 @@ class Job(object):
 
     __metaclass__ = abc.ABCMeta
     _lock = threading.Lock()
+    index_counter = 0
 
     def __init__(self, uid, data, notify_end):
         """Initialize worker.
@@ -66,6 +67,12 @@ class Job(object):
         self.interrupted = False
         self.queue_name = 'default'
         self.tokens = 1
+        with self._lock:
+            self.index = Job.index_counter
+            Job.index_counter += 1
+
+    def __lt__(self, other):
+        return self.index < other.index
 
     def record_start_time(self):
         with self._lock:

--- a/e3/job/scheduler.py
+++ b/e3/job/scheduler.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import heapq
 import time
-from collections import deque
 from datetime import datetime
 from Queue import Empty, Queue
 
@@ -73,7 +73,7 @@ class Scheduler(object):
 
         # Create the queues
         for name, max_token in queues.iteritems():
-            self.queues[name] = deque()
+            self.queues[name] = []
             self.tokens[name] = max_token
             self.n_tokens += max_token
 
@@ -183,7 +183,7 @@ class Scheduler(object):
                     self.collect(job)
                     self.dag_iterator.leave(uid)
                 else:
-                    self.queues[job.queue_name].append(job)
+                    heapq.heappush(self.queues[job.queue_name], job)
                     self.queued_jobs += 1
         except StopIteration:
             self.all_jobs_queued = True
@@ -196,7 +196,7 @@ class Scheduler(object):
         for name in self.queues:
             q = self.queues[name]
             while q and q[0].tokens <= self.tokens[name]:
-                next_job = q.popleft()
+                next_job = heapq.heappop(q)
                 next_job.start(slot=self.slots.pop())
                 self.tokens[name] -= next_job.tokens
                 self.queued_jobs -= 1
@@ -246,7 +246,7 @@ class Scheduler(object):
 
                 if self.collect(job):
                     # Requeue when needed
-                    self.queues[job.queue_name].append(job)
+                    heapq.heappush(self.queues[job.queue_name], job)
                     self.queued_jobs += 1
                 else:
                     # Mark the job as completed

--- a/tests/tests_e3/job/scheduling_test.py
+++ b/tests/tests_e3/job/scheduling_test.py
@@ -14,6 +14,9 @@ class NopJob(Job):
     def run(self):
         pass
 
+    def __lt__(self, other):
+        return str(self.uid) < str(other.uid)
+
 
 class SleepJob(ProcessJob):
 
@@ -32,6 +35,22 @@ class TestScheduler(object):
         s = Scheduler(Scheduler.simple_provider(NopJob), tokens=2)
         s.run(dag)
         assert s.max_active_jobs == 2
+
+    def test_ordering(self):
+        """Test that jobs are ordered correctly."""
+        results = []
+
+        def collect(job):
+            results.append(job.uid)
+
+        dag = DAG()
+        dag.add_vertex('3')
+        dag.add_vertex('0')
+        dag.add_vertex('1')
+        s = Scheduler(Scheduler.simple_provider(NopJob), tokens=1,
+                      collect=collect)
+        s.run(dag)
+        assert tuple(results) == ('0', '1', '3')
 
     def test_minimal_run2(self):
         """Test with two interdependent jobs."""


### PR DESCRIPTION
If the Job class support comparison, job preference will be from
lower to highest value. Thus notion of priority can be introduced
by implementing the __cmp__ builtin function in a Job subclass