### PR TITLE
Review use of priorities in e3.job.scheduler

### DIFF
--- a/e3/job/__init__.py
+++ b/e3/job/__init__.py
@@ -77,18 +77,15 @@ class Job(object):
             self.index = Job.index_counter
             Job.index_counter += 1
 
-    def __lt__(self, other):
-        """Compare two jobs.
+    @property
+    def priority(self):
+        """Return job priority.
 
-        This method can be reimplemented in order to provider other
-        priority systems.
+        This is used in ``e3.job.scheduler.Scheduler``.
 
-        :param other: another Job
-        :type other: Job
-        :return: True if self has a strictly higher priority than other
-        :rtype: bool
+        :return: int
         """
-        return self.index < other.index
+        return 0
 
     def record_start_time(self):
         """Log the starting time of a job."""

--- a/tests/tests_e3/job/scheduling_test.py
+++ b/tests/tests_e3/job/scheduling_test.py
@@ -14,8 +14,13 @@ class NopJob(Job):
     def run(self):
         pass
 
-    def __lt__(self, other):
-        return str(self.uid) < str(other.uid)
+    @property
+    def priority(self):
+        try:
+            result = -int(self.uid)
+        except Exception:
+            result = 0
+        return result
 
 
 class SleepJob(ProcessJob):


### PR DESCRIPTION
1- by default all jobs have the same priority
2- ensure stability of the queue when two jobs have the same priority