### PR TITLE
SourceBuilder checkout property should not be None

### DIFF
--- a/e3/anod/package.py
+++ b/e3/anod/package.py
@@ -152,7 +152,7 @@ class SourceBuilder(object):
         :type kind: str
         """
         self.name = name
-        self.checkout = checkout
+        self.checkout = checkout if checkout is not None else []
         self.repositories = {}
         self.kind = kind
         self.from_spec = None
@@ -175,11 +175,6 @@ class SourceBuilder(object):
         """
         if self.__prepare_src is not None:
             return self.__prepare_src
-        elif self.checkout is None:
-            # Checkout set to None, it means that there is no way
-            # to create a source package via Anod.
-            # This can be true for third party packages
-            return None
 
         # Else provide a default function if we have exactly 1 checkout
         if not self.checkout:
@@ -235,7 +230,10 @@ class SourceBuilder(object):
 class UnmanagedSourceBuilder(SourceBuilder):
     """Source builder for sources not managed by anod."""
 
-    pass
+    @property
+    def prepare_src(self):
+        """Do not create source package."""
+        return None
 
 
 class ThirdPartySourceBuilder(UnmanagedSourceBuilder):

--- a/tests/tests_e3/anod/context_data/spec11.anod
+++ b/tests/tests_e3/anod/context_data/spec11.anod
@@ -1,6 +1,6 @@
 from e3.anod.spec import Anod
 from e3.anod.package import ExternalSourceBuilder, \
-    UnmanagedSourceBuilder, Source
+    ThirdPartySourceBuilder, Source
 
 
 class Spec11(Anod):
@@ -12,10 +12,7 @@ class Spec11(Anod):
     build_deps = [Anod.Dependency('spec1', require='source_pkg')]
 
     source_pkg_build = [
-        UnmanagedSourceBuilder(
-            name='unmanaged-src',
-            fullname=lambda x: 'unmanaged-src',
-            checkout=['spec1-git']),
+        ThirdPartySourceBuilder(name='unmanaged-src'),
         ExternalSourceBuilder(name='external-src')]
 
     @Anod.primitive()

--- a/tests/tests_e3/anod/test_package.py
+++ b/tests/tests_e3/anod/test_package.py
@@ -44,6 +44,10 @@ def test_source_builder_default_prepare_src():
         with pytest.raises(e3.anod.error.SpecError):
             assert sb_err.prepare_src
 
+    # Check ThirdParty prepare_src is None
+    tp = e3.anod.package.ThirdPartySourceBuilder(name='unmanaged-src')
+    assert tp.prepare_src is None
+
 
 def test_source_builder_custom_prepare_src():
     """Test SourceBuilder with a custom prepare_src function."""
@@ -58,16 +62,6 @@ def test_source_builder_custom_prepare_src():
 
     sb.prepare_src(None, os.getcwd())
     assert os.path.exists('my_generated_source_file')
-
-
-def test_source_builder_no_checkout():
-    """SourceBuilder.prepare_src should be None when checkout=None."""
-    sb = e3.anod.package.SourceBuilder(
-        name='c-src',
-        fullname=lambda: 'c-src.tgz',
-        checkout=None)
-
-    assert sb.prepare_src is None
 
 
 def test_apply_patch():


### PR DESCRIPTION
- change checkout default value to empty list
- remove test_source_builder_no_checkout
- add check ThirdPartySourceBuilder object prepare_src is None
- spec11 call ThirdPartySourceBuilder instead Unmanaged