### PR TITLE
new (abstract) classes JobController and StatusBasedJobController in e3.jobs

### DIFF
--- a/e3/job/__init__.py
+++ b/e3/job/__init__.py
@@ -2,9 +2,11 @@ from __future__ import absolute_import, division, print_function
 
 from collections import namedtuple
 from datetime import datetime
+from e3.anod.status import ReturnValue
 from e3.os.process import Run
 import abc
 import e3.log
+import logging
 import threading
 
 logger = e3.log.getLogger('job')
@@ -154,6 +156,27 @@ class Job(object):
         return not previous_state
 
 
+class EmptyJob(Job):
+    """A job which does nothing.
+
+    :ivar status: The job's status.
+    :vartype status: ReturnValue
+    """
+
+    def __init__(self, uid, data, notify_end, status=ReturnValue.force_skip):
+        """Initialize the EmptyJob.
+
+        :param status: The job's status.
+        :type status: ReturnValue
+        """
+        super(EmptyJob, self).__init__(uid, data, notify_end)
+        self.should_skip = True
+        self.status = status
+
+    def run(self):
+        pass
+
+
 class ProcessJob(Job):
     """Specialized version of Job that spawn processes.
 
@@ -221,3 +244,156 @@ class ProcessJob(Job):
                 self.proc_handle.kill(recursive=True)
             else:  # defensive code
                 logger.debug('cannot interrupt, job %s has finished', self.uid)
+
+
+class JobController(object):
+    """An abstract class to control a job and its dependencies."""
+
+    @abc.abstractmethod
+    def get_job(self, uid, data, predecessors, notify_end):
+        """Return a Job.
+
+        :param uid: A unique Job ID.
+        :type uid: str
+        :param data: Data associated to the job to create.
+        :type data: T
+        :param predecessors: A list of predecessor jobs, or None.
+        :type predecessors: list[str] | None
+        :notify_end: Same as the notify_end parameter in Job.__init__.
+        :type notify_end: str -> None
+        :rtype: Job
+        """
+        pass  # all: no cover
+
+    @abc.abstractmethod
+    def collect(self, job):
+        """Collect the status of the given job.
+
+        Return True if the job has been requeued, False otherwise.
+
+        :param job: The job to collect.
+        :type job: ProcessJob
+        :rtype: bool
+        """
+        pass  # all: no cover
+
+
+class StatusBasedJobController(JobController):
+    """A job controller taking job status into account.
+
+    :ivar actions: DAG of actions to perform.
+    :vartype actions: DAG
+    :ivar job_status: A dictionary of job status (ReturnValue), indexed by
+        job unique IDs.
+    :vartype: dict
+    """
+
+    def __init__(self, actions):
+        """Initialize a JobController.
+
+        :param actions: DAG of actions to perform.
+        :type actions: DAG
+        """
+        self.actions = actions
+        self.job_status = {}
+
+    def create_failed_job(self, uid, data, predecessors, reason, notify_end):
+        """Return a failed job.
+
+        This method always returns an EmptyJob. Deriving classes may
+        override this method if they need something more specific.
+
+        :param uid: A unique Job ID.
+        :type uid: str
+        :param data: Data associated to the job to create.
+        :type data: T
+        :param predecessors: A list of predecessor jobs, or None.
+        :type predecessors: list[str] | None
+        :param reason: If not None, the reason for creating a failed job.
+        :type reason: str | None
+        :notify_end: Same as the notify_end parameter in Job.__init__.
+        :type notify_end: str -> None
+        :rtype: Job
+        """
+        return EmptyJob(uid, data, notify_end)
+
+    @abc.abstractmethod
+    def create_job(self, uid, data, predecessors, notify_end):
+        """Create a ProcessJob.
+
+        :param uid: A unique Job ID.
+        :type uid: str
+        :param data: Data associated to the job to create.
+        :type data: T
+        :param predecessors: A list of predecessor jobs, or None.
+        :type predecessors: list[str] | None
+        :notify_end: Same as the notify_end parameter in Job.__init__.
+        :type notify_end: str -> None
+        :rtype: ProcessJob
+        """
+        pass  # all: no cover
+
+    @abc.abstractmethod
+    def request_requeue(self, job):
+        """Requeue the given job.
+
+        Return True if the job has been requeued, False otherwise.
+
+        :param job: The job to requeue.
+        :type job: ProcessJob
+        :rtype: bool
+        """
+        pass  # all: no cover
+
+    def get_job(self, uid, data, predecessors, notify_end):
+        """Return a Job.
+
+        Same as self.create_job except that this function first checks
+        whether any of the predecessors might have failed, in which case
+        the failed job (creating using the create_failed_job method)
+        is returned.
+
+        :rtype: Job
+        """
+        # First check status of all predecessors
+        failed_predecessors = [k for k in predecessors
+                               if self.job_status[k] not in
+                               (ReturnValue.success,
+                                ReturnValue.skip,
+                                ReturnValue.force_skip)]
+        if failed_predecessors:
+            force_fail = "Event failed because of prerequisite failure:\n"
+            force_fail += "\n".join(["  " + str(self.actions[k])
+                                     for k in failed_predecessors])
+            return self.create_failed_job(uid, data, predecessors,
+                                          force_fail, notify_end)
+
+        return self.create_job(uid, data, predecessors, notify_end)
+
+    def collect(self, job):
+        """Collect all the results from the given job.
+
+        :param job: The job whose results we need to collect.
+        :type job: ProcessJob
+        """
+        if job.should_skip:
+            self.job_status[job.uid] = ReturnValue(job.status)
+            if job.status not in (ReturnValue.force_fail,
+                                  ReturnValue.force_skip):
+                logging.info("[queue=%-10s status=%3d time=%5ds] %s",
+                             job.queue_name, self.job_status[job.uid],
+                             0, job.data)
+            return False
+
+        self.job_status[job.uid] = ReturnValue(job.proc_handle.status)
+        logging.info("[queue=%-10s status=%3d time=%5ds] %s",
+                     job.queue_name,
+                     job.proc_handle.status,
+                     int(job.timing_info.duration),
+                     job.data)
+
+        requeued = False
+        if self.job_status[job.uid] == ReturnValue.notready:
+            requeued = self.request_requeue(job)
+
+        return requeued

--- a/tests/tests_e3/job/job_controller_test.py
+++ b/tests/tests_e3/job/job_controller_test.py
@@ -1,0 +1,199 @@
+from __future__ import absolute_import, division, print_function
+
+import sys
+
+from e3.anod.status import ReturnValue
+from e3.collection.dag import DAG
+from e3.job import EmptyJob, ProcessJob, StatusBasedJobController
+
+
+class ControlledJob(ProcessJob):
+    """A ProcessJob for testing purposes.
+
+    The process's behavior is configured by the suffix's UID (see
+    the "cmd" line method for more details on this.
+    """
+
+    def __init__(self, uid, data, notify_end):
+        super(ControlledJob, self).__init__(uid, data, notify_end)
+        self.run_count = 0
+
+    def run(self):
+        self.run_count += 1
+        return super(ControlledJob, self).run()
+
+    @property
+    def cmdline(self):
+        result = [sys.executable, '-c']
+        if self.uid.endswith('bad'):
+            result.append('import sys; sys.exit(1)')
+        elif self.uid.endswith('notready:once') and self.run_count < 2:
+            result.append('import sys; sys.exit(%d)'
+                          % ReturnValue.notready.value)
+        elif self.uid.endswith('notready:always'):
+            result.append('import sys; sys.exit(%d)'
+                          % ReturnValue.notready.value)
+        else:
+            result.append('print("Hello World")')
+        return result
+
+
+class SimpleController(StatusBasedJobController):
+    """A Simple controller."""
+
+    def __init__(self, actions):
+        super(SimpleController, self).__init__(actions)
+        # The list of jobs (by UID) that have been requeued.
+        self.requeued = {}
+
+    def request_requeue(self, job):
+        """Requeue the job is not already queued once."""
+        # First record the number of times we've been asked to requeue
+        # that job, and allow requeuing only twice.
+        if job.uid not in self.requeued:
+            self.requeued[job.uid] = 0
+        self.requeued[job.uid] += 1
+        return self.requeued[job.uid] < 3
+
+    def create_job(self, uid, data, predecessors, notify_end):
+        if uid.endswith('dry-run'):
+            # Create a dry-run job, which is a job that never runs
+            # (EmptyJob) and returns ReturnValue.success.
+            return EmptyJob(uid, data, notify_end, ReturnValue.success)
+        else:
+            return ControlledJob(uid, data, notify_end)
+
+
+class TestStatusBasedJobController(object):
+
+    def test_good_job_no_predecessors(self):
+        """Simple case of a leaf job."""
+        actions = DAG()
+        actions.add_vertex('1')
+        c = SimpleController(actions)
+
+        job = c.get_job('1', None, [], print)
+        assert isinstance(job, ControlledJob)
+        assert job.should_skip is False
+        job.run()
+        c.collect(job)
+        assert c.job_status == {'1': ReturnValue.success}
+        assert c.requeued == {}
+
+    def test_bad_job_no_predecessors(self):
+        """Simple case of a leaf job failing."""
+        actions = DAG()
+        actions.add_vertex('1.bad')
+        c = SimpleController(actions)
+
+        job = c.get_job('1.bad', None, [], print)
+        assert isinstance(job, ControlledJob)
+        assert job.should_skip is False
+        job.run()
+        requeued = c.collect(job)
+        assert not requeued
+        assert c.job_status == {'1.bad': ReturnValue(1)}
+        assert c.requeued == {}
+
+    def test_failed_predecessor(self):
+        """Simulate the scenarior when a predecessor failed."""
+        actions = DAG()
+        actions.add_vertex('1.bad')
+        actions.add_vertex('2', predecessors=['1.bad'])
+        c = SimpleController(actions)
+
+        job = c.get_job('1.bad', None, [], print)
+        assert isinstance(job, ControlledJob)
+        assert job.should_skip is False
+        job.run()
+        requeued = c.collect(job)
+        assert not requeued
+        assert c.job_status == {'1.bad': ReturnValue(1)}
+        assert c.requeued == {}
+
+        job = c.get_job('2', None, ['1.bad'], print)
+        assert isinstance(job, EmptyJob)
+        assert job.should_skip is True
+        job.run()
+        requeued = c.collect(job)
+        assert not requeued
+        assert c.job_status == {'1.bad': ReturnValue(1),
+                                '2': ReturnValue.force_skip}
+        assert c.requeued == {}
+
+    def test_job_not_ready_then_ok(self):
+        """Rerunning a job that first returned notready."""
+        actions = DAG()
+        actions.add_vertex('1.notready:once')
+        c = SimpleController(actions)
+
+        job = c.get_job('1.notready:once', None, [], print)
+        assert isinstance(job, ControlledJob)
+        assert job.should_skip is False
+        job.run()
+        requeued = c.collect(job)
+        assert requeued is True
+        assert c.job_status == {'1.notready:once': ReturnValue.notready}
+        assert c.requeued == {'1.notready:once': 1}
+
+        job.run()
+        requeued = c.collect(job)
+        assert requeued is False
+        assert c.job_status == {'1.notready:once': ReturnValue.success}
+        assert c.requeued == {'1.notready:once': 1}
+
+    def test_job_never_ready(self):
+        """Trying to run a job repeatedly returning notready."""
+        actions = DAG()
+        actions.add_vertex('1.notready:always')
+        c = SimpleController(actions)
+
+        job = c.get_job('1.notready:always', None, [], print)
+        assert isinstance(job, ControlledJob)
+        assert job.should_skip is False
+        job.run()
+        requeued = c.collect(job)
+        assert requeued is True
+        assert c.job_status == {'1.notready:always': ReturnValue.notready}
+        assert c.requeued == {'1.notready:always': 1}
+
+        # Try running again. We should be getting the same outcome.
+        job.run()
+        requeued = c.collect(job)
+        assert requeued is True
+        assert c.job_status == {'1.notready:always': ReturnValue.notready}
+        assert c.requeued == {'1.notready:always': 2}
+
+        # Try running again. Still not ready, but no requeuing done
+        # anymore.
+        job.run()
+        requeued = c.collect(job)
+        assert requeued is False
+        assert c.job_status == {'1.notready:always': ReturnValue.notready}
+        assert c.requeued == {'1.notready:always': 3}
+
+    def test_dry_run(self):
+        """Simulate the use actions with "dry run" behavior."""
+        actions = DAG()
+        actions.add_vertex('1.dry-run')
+        actions.add_vertex('2.dry-run', predecessors=['1.dry-run'])
+        c = SimpleController(actions)
+
+        job = c.get_job('1.dry-run', None, [], print)
+        assert isinstance(job, EmptyJob)
+        assert job.should_skip is True
+        job.run()
+        requeued = c.collect(job)
+        assert requeued is False
+        assert c.job_status == {'1.dry-run': ReturnValue.success}
+        assert c.requeued == {}
+
+        job = c.get_job('2.dry-run', None, [], print)
+        assert isinstance(job, EmptyJob)
+        assert job.should_skip is True
+        job.run()
+        requeued = c.collect(job)
+        assert requeued is False
+        assert c.job_status == {'1.dry-run': ReturnValue.success,
+                                '2.dry-run': ReturnValue.success}
+        assert c.requeued == {}


### PR DESCRIPTION
This patch first introduces the root class JobController providing
abstract methods get_job and collect. The interface of those two
methods is intentionally set to match the "get_job" and "collect"
parameters of e3.job.Scheduler.__init__.

It then introduces a class StatusBasedJobController deriving from
JobController, which is still abstract, but specializes it to
provide handling for the job status of the job we create as well
as the status of its predecessors.

For QB17-039.