### PR TITLE
tox.ini: Add stylechecks to the list of default checks to run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-cov
+envlist = py27-cov,checkstyle
 
 [testenv]
 deps =


### PR DESCRIPTION
Tested by running "tox" without argument and verifying that we now
get checkstyle testing in addition to running the testsuite with
coverage analysis.

For QC04-036.