### PR TITLE
Allow SSL connection to the smtp server

### DIFF
--- a/e3/net/smtp.py
+++ b/e3/net/smtp.py
@@ -65,9 +65,12 @@ def sendmail(from_email, to_emails, mail_as_string, smtp_servers,
         # No system sendmail, return False
         return False
 
+    smtp_class = smtplib.SMTP_SSL if 'smtp_ssl' in os.environ.get(
+        'E3_ENABLE_FEATURE', '').split(',') else smtplib.SMTP
+
     for smtp_server in smtp_servers:
         try:
-            s = smtplib.SMTP(smtp_server)
+            s = smtp_class(smtp_server)
         except (socket.error, smtplib.SMTPException) as e:
             logger.debug(e)
             logger.debug('cannot connect to smtp server %s', smtp_server)


### PR DESCRIPTION
Switch to SMTP_SSL when the environment variable
E3_ENABLE_FEATURE (csv format) contains the value smtp_ssl

TN: QC19-029