### PR TITLE
enhance class Anod.BuildSpace to reuse class Fingerprint's load/save methods

### DIFF
--- a/e3/anod/buildspace.py
+++ b/e3/anod/buildspace.py
@@ -105,6 +105,15 @@ class BuildSpace(object):
         for d in (d for d in self.dirs if d not in keep):
             rm(self.get_subdir(name=d), True)
 
+    def fingerprint_filename(self, kind):
+        """Return the absolute path to the fingerprint of the given primitive.
+
+        :param kind: the primitive name
+        :type kind: str
+        :rtype: str
+        """
+        return os.path.join(self.meta_dir, kind + '_fingerprint.yaml')
+
     def update_status(self, kind, status=ReturnValue.failure,
                       fingerprint=None):
         """Update meta information on disk.
@@ -139,8 +148,7 @@ class BuildSpace(object):
             exist)
         :rtype: str | Fingerprint
         """
-        fingerprint_file = os.path.join(
-            self.meta_dir, kind + '_fingerprint.yaml')
+        fingerprint_file = self.fingerprint_filename(kind)
         if sha1_only:
             return sha1(fingerprint_file)
 
@@ -169,8 +177,7 @@ class BuildSpace(object):
         :param fingerprint: the fingerprint object to save
         :type fingerprint: Fingerprint
         """
-        fingerprint_file = os.path.join(
-            self.meta_dir, kind + '_fingerprint.yaml')
+        fingerprint_file = self.fingerprint_filename(kind)
         with open(fingerprint_file, 'wb') as f:
             yaml.dump(fingerprint, f, encoding='utf-8')
 

--- a/tests/tests_e3/anod/test_buildspace.py
+++ b/tests/tests_e3/anod/test_buildspace.py
@@ -56,7 +56,7 @@ def test_fingerprint():
 
     # Now make sure that load_fingerprint does not fail when the bumped
     # value is corrupted
-    with open(os.path.join(bs.meta_dir, 'build_fingerprint.yaml'), 'w') as f:
+    with open(bs.fingerprint_filename('build'), 'w') as f:
         f.write('[')
 
     assert bs.load_fingerprint(kind='build') == Fingerprint()


### PR DESCRIPTION
All in the subject and in the commits' revision log.

Small note: This is unrelated to this pull request, but I noticed that BuildSpace.load_fingerprint has a "sha_only" option, where the current behavior is to load the contents of the file and return its sha1. Not sure if this is supposed to be correlated to class Fingerprint's sha1 method. It's something different, right?