### PR TITLE
Remove "sha1_only" parameter from Buildspace.load_fingerprint

### DIFF
--- a/e3/anod/buildspace.py
+++ b/e3/anod/buildspace.py
@@ -14,7 +14,6 @@ from e3.anod.status import ReturnValue
 from e3.error import E3Error
 from e3.fingerprint import Fingerprint
 from e3.fs import mkdir, rm
-from e3.hash import sha1
 
 logger = e3.log.getLogger('buildspace')
 
@@ -131,25 +130,18 @@ class BuildSpace(object):
         if kind == 'build':
             self.update_status('install', status, fingerprint)
 
-    def load_fingerprint(self, kind, sha1_only=False):
+    def load_fingerprint(self, kind):
         """Load the content of the fingerprint from disc.
 
         :param kind: the primitive name
         :type kind: str
-        :param sha1_only: if true returns only the checksum of the
-            fingerprint file
-        :type sha1_only: bool
 
-        :return: if sha1_only is True, returns a sha1 hexdigest else returns
-            a Fingerprint object (the content of the fingerprint file or an
-            empty Fingerprint when the fingerprint is invalid or does not
-            exist)
-        :rtype: str | Fingerprint
+        :return: Returns a Fingerprint object (the content of the fingerprint
+            file or an empty Fingerprint when the fingerprint is invalid
+            or does not exist).
+        :rtype: Fingerprint
         """
         fingerprint_file = self.fingerprint_filename(kind)
-        if sha1_only:
-            return sha1(fingerprint_file)
-
         result = None
         if os.path.exists(fingerprint_file):
             try:

--- a/tests/tests_e3/anod/test_buildspace.py
+++ b/tests/tests_e3/anod/test_buildspace.py
@@ -47,10 +47,6 @@ def test_fingerprint():
     fp.add('foo', 'bar')
     bs.save_fingerprint(kind='build', fingerprint=fp)
 
-    # Check that the fingerprint stored on disk is equal to fp
-    fp_checksum = bs.load_fingerprint(kind='build', sha1_only=True)
-    assert isinstance(fp_checksum, str)
-
     loaded_fp = bs.load_fingerprint(kind='build')
     assert loaded_fp == fp
 


### PR DESCRIPTION
Just a quick followup on the suggestion made in discussions over pull request #179.