### PR TITLE
Ignore/remove pycodestyle warnings

### DIFF
--- a/e3/fs.py
+++ b/e3/fs.py
@@ -1,5 +1,4 @@
 """High-Level file manipulation."""
-
 from __future__ import absolute_import, division, print_function
 
 import fnmatch
@@ -552,7 +551,6 @@ def sync_tree(source, target, ignore=None,
 
         :param fi: a FileInfo namedtuple
         :type fi: FileInfo
-
         :return: True if fi is a regular file
         :rtype: bool
         """

--- a/tests/tests_e3/sys/main_test.py
+++ b/tests/tests_e3/sys/main_test.py
@@ -31,7 +31,7 @@ from foo.bar2.module3 import name1
             RewriteImportRule('b'),
             RewriteImportRule('a'),
             RewriteImportRule('.*3'),
-            RewriteImportRule('.*\.bar\..*', 'name2')
+            RewriteImportRule(r'.*\.bar\..*', 'name2')
         ]
     ).visit(node)
 
@@ -84,7 +84,7 @@ from foo.bar2.module3 import name1
                     action=RewriteImportRule.RuleAction.reject),
                 RewriteImportRule('b'),
                 RewriteImportRule('.*3'),
-                RewriteImportRule('.*\.bar\..*', 'name2')
+                RewriteImportRule(r'.*\.bar\..*', 'name2')
             ]
         ).visit(node2)
 
@@ -101,7 +101,7 @@ from foo.bar2.module3 import name1
                 RewriteImportRule('b'),
                 RewriteImportRule('.*3'),
                 RewriteImportRule(
-                    '.*\.bar\..*', 'name2',
+                    r'.*\.bar\..*', 'name2',
                     action=RewriteImportRule.RuleAction.reject)
             ]
         ).visit(node3)

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ commands =
       python -msphinx -M html {toxinidir}/docs/source {toxinidir}/docs/build
 
 [pycodestyle]
-ignore = E123,E133,E241,E242
+ignore = E123,E133,E241,E242,W503,W504
 
 [pydocstyle]
 ignore = D100,D101,D102,D102,D103,D104,D105,D106,D107,D203,D403,D213


### PR DESCRIPTION
These warnings are already ignored in default configuration.