### PR TITLE
add data parameter Walk::compute_new_fingerprint

### DIFF
--- a/e3/job/walk.py
+++ b/e3/job/walk.py
@@ -62,7 +62,7 @@ class Walk(object):
         self.tokens = 1
         self.job_timeout = DEFAULT_JOB_MAX_DURATION
 
-    def compute_new_fingerprint(self, uid):
+    def compute_new_fingerprint(self, uid, data):
         """Compute the given action's Fingerprint.
 
         This method is expected to return a Fingerprint corresponding
@@ -75,6 +75,8 @@ class Walk(object):
 
         :param uid: A unique Job ID.
         :type uid: str
+        :param data: Data associated to the job.
+        :type data: T
         :rtype: e3.fingerprint.Fingerprint | None
         """
         return None
@@ -213,7 +215,7 @@ class Walk(object):
         :rtype: Job
         """
         prev_fingerprint = self.load_previous_fingerprint(uid)
-        self.new_fingerprints[uid] = self.compute_new_fingerprint(uid)
+        self.new_fingerprints[uid] = self.compute_new_fingerprint(uid, data)
         self.save_fingerprint(uid, None)
 
         # Check our predecessors. If any of them failed, then return

--- a/e3/job/walk.py
+++ b/e3/job/walk.py
@@ -192,6 +192,13 @@ class Walk(object):
         """
         if previous_fingerprint is None or new_fingerprint is None:
             return True
+        for pred_uid in self.actions.vertex_predecessors[uid]:
+            if self.new_fingerprints[pred_uid] is None:
+                # One of the predecessors has no fingerprint, so
+                # this node's new_fingerprint cannot tell us whether
+                # this dependency has changed or not. We therefore
+                # need to run this action.
+                return True
         return previous_fingerprint != new_fingerprint
 
     def create_failed_job(self, uid, data, predecessors, reason, notify_end):

--- a/e3/job/walk.py
+++ b/e3/job/walk.py
@@ -165,7 +165,7 @@ class Walk(object):
         :param data: Data associated to the job to create.
         :type data: T
         :param predecessors: A list of predecessor jobs, or None.
-        :type predecessors: list[str] | None
+        :type predecessors: list[e3.job.Job] | None
         :param reason: If not None, the reason for creating a failed job.
         :type reason: str | None
         :notify_end: Same as the notify_end parameter in Job.__init__.
@@ -183,7 +183,7 @@ class Walk(object):
         :param data: Data associated to the job to create.
         :type data: T
         :param predecessors: A list of predecessor jobs, or None.
-        :type predecessors: list[str] | None
+        :type predecessors: list[e3.job.Job] | None
         :notify_end: Same as the notify_end parameter in Job.__init__.
         :type notify_end: str -> None
         :rtype: ProcessJob

--- a/tests/tests_e3/job/walk_test.py
+++ b/tests/tests_e3/job/walk_test.py
@@ -154,7 +154,7 @@ class FingerprintWalk(SimpleWalk):
     def fingerprint_filename(cls, uid):
         return os.path.join(FINGERPRINT_DIR, uid)
 
-    def compute_new_fingerprint(self, uid):
+    def compute_new_fingerprint(self, uid, data):
         f = Fingerprint()
         for pred_uid in self.actions.vertex_predecessors[uid]:
             pred_fingerprint = self.load_previous_fingerprint(pred_uid)


### PR DESCRIPTION
When it came time to actually implement this method in the context of e3-electrolyt, I realized that we needed the data corresponding to each Job, so the second commit adds it. The first commit just fixes some documentation that I noticed while looking at the predecessors list.