### PR TITLE
Temporarly allow usage of sha1sum

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,13 +40,14 @@ commands =
 
 [testenv:security]
 # Run bandit checks. Accept yaml.load(), pickle, and exec since this
-# is needed by e3. There is also e3.env.tmp_dir that returns the TMPDIR
+# is needed by e3. Also temporarly accept sha1 usage until this is replaced by
+# more secure alternative. There is also e3.env.tmp_dir that returns the TMPDIR
 # environment variable. Don't check for that.
 deps =
       bandit
       safety
 commands =
-      bandit -r e3 -ll -ii -s B102,B108,B301,B506
+      bandit -r e3 -ll -ii -s B102,B108,B301,B303,B506
       safety check --full-report
 
 [testenv:docs]


### PR DESCRIPTION
It will be replaced by more secure alternative in the future but
the current usage is not really problematic for now.