### PR TITLE
Show ReturnValue name instead of value

### DIFF
--- a/e3/anod/status.py
+++ b/e3/anod/status.py
@@ -12,5 +12,5 @@ class ReturnValue(Enum):
     notready = 75
     force_skip = 122
     force_fail = 123
-    status_unknown = 124
+    unknown = 124
     skip = 125

--- a/e3/electrolyt/run.py
+++ b/e3/electrolyt/run.py
@@ -32,7 +32,7 @@ class ElectrolytJob(Job):
     """
 
     def __init__(self, uid, data, notify_end, sandbox, store,
-                 force_status=STATUS.status_unknown,
+                 force_status=STATUS.unknown,
                  dry_run=False):
         """Initialize the context of the job.
 
@@ -58,7 +58,7 @@ class ElectrolytJob(Job):
         self.store = store
 
     def run(self):
-        if self.__status == STATUS.status_unknown and not self.dry_run:
+        if self.__status == STATUS.unknown and not self.dry_run:
             try:
                 getattr(self, self.data.run_method)()
             except Exception as e:
@@ -197,16 +197,16 @@ class ElectrolytJobFactory(object):
             notify_end,
             sandbox=self.sandbox,
             store=self.store,
-            force_status=(STATUS.status_unknown
+            force_status=(STATUS.unknown
                           if not force_fail
                           else STATUS.failure),
             dry_run=self.dry_run)
 
     def collect(self, job):
         self.job_status[job.uid] = job.status
-        logger.info("%-48s [queue=%-10s status=%03d]",
+        logger.info("%-48s [queue=%-10s status=%-10s]",
                     job.data, job.queue_name,
-                    self.job_status[job.uid].value)
+                    self.job_status[job.uid].name)
 
     def run(self, action_list):
         sch = Scheduler(self.get_job, self.collect)

--- a/e3/job/walk.py
+++ b/e3/job/walk.py
@@ -319,14 +319,14 @@ class Walk(object):
         if job.should_skip:
             if job.status not in (ReturnValue.force_fail,
                                   ReturnValue.force_skip):
-                logging.info("[queue=%-10s status=%3d time=%5ds] %s",
-                             job.queue_name, self.job_status[job.uid].value,
+                logging.info("[queue=%-10s status=%-10s time=%5ds] %s",
+                             job.queue_name, self.job_status[job.uid].name,
                              0, job.data)
             return False
 
-        logging.info("[queue=%-10s status=%3d time=%5ds] %s",
+        logging.info("[queue=%-10s status=%-10s time=%5ds] %s",
                      job.queue_name,
-                     job.status.value,
+                     job.status.name,
                      int(job.timing_info.duration),
                      job.data)
 

--- a/tests/tests_e3/anod/test_sandbox.py
+++ b/tests/tests_e3/anod/test_sandbox.py
@@ -449,8 +449,8 @@ def test_failure_status(git_specs_dir):
          '--plan', os.path.join(root_dir, 'test.plan'),
          sandbox_dir])
     # the dag for this plan has 6 actions and thus we need to have
-    # 6 failure status (status=001)
-    assert p.out.count('status=001') == 6, p.out
+    # 6 failure status (status=failure)
+    assert p.out.count('status=failure') == 6, p.out
     assert 'GITURL' in p.out, p.out
 
     # Try with an unsupported VCS
@@ -463,7 +463,7 @@ def test_failure_status(git_specs_dir):
          '--plan', os.path.join(root_dir, 'test.plan'),
          sandbox_dir])
     assert 'unsupported-vcs vcs type not supported' in p.out, p.out
-    assert p.out.count('status=001') == 6, p.out
+    assert p.out.count('status=failure') == 6, p.out
 
     # Also check with a missing repo
     e3.anod.helper.text_replace(
@@ -475,4 +475,4 @@ def test_failure_status(git_specs_dir):
          '--plan', os.path.join(root_dir, 'test.plan'),
          sandbox_dir])
     assert 'dummy-github configuration missing' in p.out, p.out
-    assert p.out.count('status=001') == 6, p.out
+    assert p.out.count('status=failure') == 6, p.out


### PR DESCRIPTION
When showing electrolyt job results it is easier to read status=skip

instead of having to remember what status=125 means