### PR TITLE
Allow setting specs_dir using user.yaml

### DIFF
--- a/e3/anod/sandbox/action.py
+++ b/e3/anod/sandbox/action.py
@@ -150,7 +150,7 @@ class SandBoxExec(SandBoxCreate):
     def add_parsers(self):
         super(SandBoxExec, self).add_parsers()
         self.parser.add_argument(
-            '--spec-dir',
+            '--specs-dir',
             help='Alternate spec directory to use')
         self.parser.add_argument(
             '--create-sandbox',
@@ -170,19 +170,15 @@ class SandBoxExec(SandBoxCreate):
         sandbox = SandBox()
         sandbox.root_dir = args.sandbox
 
-        if args.spec_dir:
-            sandbox_spec_dir = args.spec_dir
-        else:
-            sandbox_spec_dir = os.path.join(
-                sandbox.root_dir,
-                'specs')
+        if args.specs_dir:
+            sandbox.specs_dir = args.specs_dir
 
         if args.create_sandbox:
             sandbox.create_dirs()
 
         if args.create_sandbox and args.spec_git_url:
-            mkdir(sandbox_spec_dir)
-            g = GitRepository(sandbox_spec_dir)
+            mkdir(sandbox.specs_dir)
+            g = GitRepository(sandbox.specs_dir)
             if e3.log.default_output_stream is not None:
                 g.log_stream = e3.log.default_output_stream
             g.init()
@@ -191,7 +187,7 @@ class SandBoxExec(SandBoxCreate):
         sandbox.dump_configuration()
         sandbox.write_scripts()
 
-        asr = AnodSpecRepository(sandbox_spec_dir)
+        asr = AnodSpecRepository(sandbox.specs_dir)
         check_api_version(asr.api_version)
 
         # Load plan content if needed

--- a/tests/tests_e3/anod/test_sandbox.py
+++ b/tests/tests_e3/anod/test_sandbox.py
@@ -175,7 +175,7 @@ def test_sandbox_exec_missing_spec_dir(git_specs_dir):
 
     # Specs dir is missing
     no_specs = e3.os.process.Run(['e3-sandbox', 'exec',
-                                  '--spec-dir', 'nospecs',
+                                  '--specs-dir', 'nospecs',
                                   '--plan',
                                   'noplan', sandbox_dir])
     assert no_specs.status != 0
@@ -215,7 +215,7 @@ def test_sandbox_action_errors(git_specs_dir):
 
     # Test with local specs
     p = e3.os.process.Run(['e3-sandbox', 'exec',
-                           '--spec-dir', os.path.join(root_dir, 'specs'),
+                           '--specs-dir', os.path.join(root_dir, 'specs'),
                            '--plan',
                            os.path.join(sandbox_dir, 'test.plan'),
                            sandbox_dir])
@@ -266,7 +266,7 @@ def test_sandbox_exec_success(git_specs_dir):
 
     # Test with local specs
     p = e3.os.process.Run(['e3-sandbox', 'exec',
-                           '--spec-dir', local_spec_dir,
+                           '--specs-dir', local_spec_dir,
                            '--plan',
                            os.path.join(sandbox_dir, 'test.plan'),
                            sandbox_dir])
@@ -278,7 +278,7 @@ def test_sandbox_exec_success(git_specs_dir):
         fd.write("anod_test('dummyspec')\n")
 
     p = e3.os.process.Run(['e3-sandbox', 'exec',
-                           '--spec-dir', local_spec_dir,
+                           '--specs-dir', local_spec_dir,
                            '--plan',
                            os.path.join(sandbox_dir, 'test.plan'),
                            sandbox_dir])
@@ -320,7 +320,7 @@ def test_sandbox_source_auto_ignore(git_specs_dir):
 
     # Test with local specs
     p = e3.os.process.Run(['e3-sandbox', 'exec',
-                           '--spec-dir', local_spec_dir,
+                           '--specs-dir', local_spec_dir,
                            '--plan',
                            os.path.join(sandbox_dir, 'test.plan'),
                            sandbox_dir])
@@ -352,7 +352,7 @@ def test_sandbox_directory(git_specs_dir):
 
     # Test with local specs
     p = e3.os.process.Run(['e3-sandbox', 'exec',
-                           '--spec-dir', local_spec_dir,
+                           '--specs-dir', local_spec_dir,
                            '--plan',
                            os.path.join(sandbox_dir, 'test.plan'),
                            sandbox_dir])
@@ -445,7 +445,7 @@ def test_failure_status(git_specs_dir):
     e3.os.process.Run(['e3-sandbox', 'create', sandbox_dir], output=None)
     p = e3.os.process.Run(
         ['e3-sandbox', '-v', 'exec',
-         '--spec-dir', local_spec_dir,
+         '--specs-dir', local_spec_dir,
          '--plan', os.path.join(root_dir, 'test.plan'),
          sandbox_dir])
     # the dag for this plan has 6 actions and thus we need to have
@@ -459,7 +459,7 @@ def test_failure_status(git_specs_dir):
         [(b'vcs: git', b'vcs: unsupported-vcs')])
     p = e3.os.process.Run(
         ['e3-sandbox', '-v', 'exec',
-         '--spec-dir', local_spec_dir,
+         '--specs-dir', local_spec_dir,
          '--plan', os.path.join(root_dir, 'test.plan'),
          sandbox_dir])
     assert 'unsupported-vcs vcs type not supported' in p.out, p.out
@@ -471,8 +471,40 @@ def test_failure_status(git_specs_dir):
         [(b'dummy-github', b'another_repo')])
     p = e3.os.process.Run(
         ['e3-sandbox', '-v', 'exec',
-         '--spec-dir', local_spec_dir,
+         '--specs-dir', local_spec_dir,
          '--plan', os.path.join(root_dir, 'test.plan'),
          sandbox_dir])
     assert 'dummy-github configuration missing' in p.out, p.out
     assert p.out.count('status=failure') == 6, p.out
+
+
+def test_sandbox_user_yaml(git_specs_dir):
+    """Verify that user.yaml specs_dir is taken into account."""
+    root_dir = os.getcwd()
+    sandbox_dir = os.path.join(root_dir, 'sbx')
+
+    e3.os.process.Run(['e3-sandbox', 'create', sandbox_dir], output=None)
+    with open(os.path.join(sandbox_dir, 'test.plan'), 'w') as fd:
+        fd.write("anod_build('dummyspec')\n")
+
+    specs_source_dir = os.path.join(os.path.dirname(__file__), 'specs')
+    local_spec_dir = os.path.join(root_dir, 'myspecs')
+
+    with open(os.path.join(sandbox_dir, 'user.yaml'), 'w') as fd:
+        yaml.dump({'specs_dir': local_spec_dir}, fd)
+
+    e3.fs.sync_tree(specs_source_dir, local_spec_dir)
+    create_prolog(local_spec_dir)
+    # Test with local specs
+    p = e3.os.process.Run(['e3-sandbox', 'exec',
+                           '--plan',
+                           os.path.join(sandbox_dir, 'test.plan'),
+                           sandbox_dir])
+    assert 'build dummyspec' in p.out
+    assert 'using alternate specs dir {}'.format(local_spec_dir) in p.out
+
+    sbx = e3.anod.sandbox.SandBox()
+    sbx.root_dir = sandbox_dir
+
+    assert sbx.is_alternate_specs_dir
+    assert sbx.specs_dir == local_spec_dir


### PR DESCRIPTION
To be compatible with our old infrastructure we still want to
parse the content of user.yaml to get the path to the directory
where to find anod specification files.