### PR TITLE
Allow passing generator to e3.fs.ls()

### DIFF
--- a/e3/fs.py
+++ b/e3/fs.py
@@ -214,6 +214,8 @@ def ls(path, emit_log_record=True):
     """
     if isinstance(path, basestring):
         path = (path, )
+    else:
+        path = list(path)
 
     if emit_log_record:
         logger.debug('ls %s', ' '.join(path))

--- a/tests/tests_e3/fs/main_test.py
+++ b/tests/tests_e3/fs/main_test.py
@@ -105,6 +105,14 @@ def test_ls(caplog):
     e3.fs.ls('a', emit_log_record=True)
     assert 'ls a' in caplog.text
 
+    e3.os.fs.touch('b')
+    e3.os.fs.touch('c')
+
+    assert e3.fs.ls('*') == ['a', 'b', 'c']
+
+    # Reproduce issue #213: add test with generator
+    assert e3.fs.ls((k for k in ('a', 'c'))) == ['a', 'c']
+
 
 def test_mkdir(caplog):
     e3.fs.mkdir('subdir')


### PR DESCRIPTION
Convert the ``path`` argument to a list in e3.fs.ls() to avoid
consuming the generator in the logger.debug statement.

Fix #213