### PR TITLE
Keep full call args information in each plan item

### DIFF
--- a/e3/electrolyt/plan.py
+++ b/e3/electrolyt/plan.py
@@ -247,7 +247,7 @@ class PlanContext(object):
         result = self.env.copy()
 
         # Process arguments
-        args = inspect.getcallargs(self.actions[name], *args, **kwargs)
+        call_args = inspect.getcallargs(self.actions[name], *args, **kwargs)
 
         # Push function arguments into the result object. If an arg value
         # is None then environment is not updated (handling of defaults
@@ -260,7 +260,7 @@ class PlanContext(object):
         # of the target. ??? change name ???
         board = None
 
-        for k, v in args.iteritems():
+        for k, v in call_args.iteritems():
             if k in platform:
                 platform[k] = v
             elif k == 'board':
@@ -294,6 +294,7 @@ class PlanContext(object):
         result.action = name
         result.plan_line = plan_line
         result.plan_args = result.to_dict()
+        result.plan_call_args = call_args
 
         # Push the action in the current list
         self.action_list.append(result)

--- a/tests/tests_e3/anod/context_test.py
+++ b/tests/tests_e3/anod/context_test.py
@@ -473,3 +473,25 @@ class TestContext(object):
                         qualifier=action.qualifier,
                         plan_line=action.plan_line,
                         plan_args=action.plan_args)
+
+    def test_plan_call_args(self):
+        """Retrieve call args values."""
+        current_env = BaseEnv()
+        cm = plan.PlanContext(server=current_env)
+
+        # Declare available actions and their signature
+        def plan_action(platform):
+            pass
+
+        cm.register_action('plan_action', plan_action)
+        # Create a simple plan
+        content = [u'def myserver():',
+                   u'    plan_action("any")']
+        with open('plan.txt', 'w') as f:
+            f.write('\n'.join(content))
+        myplan = plan.Plan({})
+        myplan.load('plan.txt')
+
+        for action in cm.execute(myplan, 'myserver'):
+            assert action.plan_call_args == {'platform': 'any'}
+            assert action.plan_args['platform'] == BaseEnv().platform


### PR DESCRIPTION
This can be useful when using args that are also defined by BaseEnv,
e.g. if you have a plan line such as build(platform="x86-windows")
you want to be able to access the "platform" value as defined in the
plan and not to go through the platform property from BaseEnv

TN: RA17-051