### PR TITLE
Protect against infinite loop after spawn issue

### DIFF
--- a/tests/tests_e3/job/job_test.py
+++ b/tests/tests_e3/job/job_test.py
@@ -48,3 +48,15 @@ class TestJob(object):
         job.run()
         assert job.status is ReturnValue.failure
         assert 'job myuid returned an unknown status 6' in caplog.text
+
+    def test_spawn_issue(self):
+        """Verify that status is set to failure when the spawn fails."""
+        class SpawnIssueProcessJob(ProcessJob):
+            @property
+            def cmdline(self):
+                # This will be called by self.run() and simulate an error
+                # when spawning the job
+                raise IOError('spawn issue')
+        job = SpawnIssueProcessJob('myuid', {}, None)
+        job.run()
+        assert job.status is ReturnValue.failure


### PR DESCRIPTION
When we cannot spawn a ProcessJob we should return a proper
error status and not "notready". We cannot know whether the spawn
issue was temporary or not, returning notready might create an
infinite loop.

TN: RA02-028