### PR TITLE
tox.ini: Stop using isort

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,12 +31,10 @@ deps =
       pycodestyle>=2.0.0,!=2.1.0
       pyflakes>=1.2.3
       pydocstyle>=1.0.0
-      isort!=4.3.0
 commands =
         pycodestyle {envsitepackagesdir}/e3 {toxinidir}/tests/
         pyflakes {envsitepackagesdir}/e3 {toxinidir}/tests
         pydocstyle {envsitepackagesdir}/e3 {toxinidir}/tests
-        isort --diff --check-only -rc {envsitepackagesdir}/e3 {toxinidir}/tests
 
 [testenv:security]
 # Run bandit checks. Accept yaml.load(), pickle, and exec since this


### PR DESCRIPTION
The tool is not stable enough, and causes more work than it helps.