### PR TITLE
Add ability to force creation of process groups on windows

### DIFF
--- a/e3/os/process.py
+++ b/e3/os/process.py
@@ -31,6 +31,10 @@ cmdlogger = e3.log.getLogger(CMD_LOGGER_NAME)
 STDOUT = subprocess.STDOUT
 PIPE = subprocess.PIPE
 
+# If feature is enabled by default we create processes on Windows
+# with the flag CREATE_NEW_PROCESS_GROUP
+WIN_NEW_PG = 'win-force-new-process-group' in \
+    os.getenv('E3_ENABLE_FEATURE', '').split(',')
 
 # Use psutil.Popen when available to get psutil.Process properties and
 # methods available in Run.internal
@@ -337,6 +341,10 @@ class Run(object):
                     # preexec_fn is no supported on windows
                     popen_args['preexec_fn'] = subprocess_setup
 
+                if WIN_NEW_PG and sys.platform == 'win32':
+                    popen_args['creationflags'] = \
+                        subprocess.CREATE_NEW_PROCESS_GROUP
+
                 self.internal = Popen(self.cmds, **popen_args)
 
             else:
@@ -370,6 +378,10 @@ class Run(object):
                             set_sigpipe:  # windows: no cover
                         # preexec_fn is no supported on windows
                         popen_args['preexec_fn'] = subprocess_setup
+
+                    if WIN_NEW_PG and sys.platform == 'win32':
+                        popen_args['creationflags'] = \
+                            subprocess.CREATE_NEW_PROCESS_GROUP
 
                     try:
                         runs.append(Popen(cmd, **popen_args))


### PR DESCRIPTION
Might reduce the scope and effect of unwanted Ctrl-C

The new feature can be enabled using E3_ENABLE_FEATURE variable
and add the win-force-new-process-group value.