### PR TITLE
Better plan error message

### DIFF
--- a/e3/anod/action/__init__.py
+++ b/e3/anod/action/__init__.py
@@ -452,14 +452,14 @@ class CreateSourceOrDownload(Decision):
             else 'DownloadSource'
 
 
-class BuildOrInstall(Decision):
+class BuildOrDownload(Decision):
     """Decision between building or downloading a component."""
 
     BUILD = Decision.LEFT
     INSTALL = Decision.RIGHT
 
     def __init__(self, root, left, right):
-        """Initialize a BuildOrInstall instance.
+        """Initialize a BuildOrDownload instance.
 
         :param root: parent node
         :type root: Install
@@ -471,9 +471,9 @@ class BuildOrInstall(Decision):
         assert isinstance(left, Build)
         assert isinstance(right, DownloadBinary)
         assert isinstance(root, Install)
-        super(BuildOrInstall, self).__init__(root=root,
-                                             left=left,
-                                             right=right)
+        super(BuildOrDownload, self).__init__(root=root,
+                                              left=left,
+                                              right=right)
 
     @classmethod
     def description(cls, decision):

--- a/e3/anod/context.py
+++ b/e3/anod/context.py
@@ -588,14 +588,19 @@ class AnodContext(object):
         :type decision: Decision
         :raise SchedulingError
         """
-        if decision.choice is None:
-            msg = 'a decision should be taken between %s%s and %s%s' % (
-                decision.left,
-                ' (expected)' if decision.expected_choice == Decision.LEFT
-                else '',
-                decision.right,
-                ' (expected)' if decision.expected_choice == Decision.RIGHT
-                else '')
+        if decision.choice is None and decision.expected_choice in (
+                Decision.LEFT, Decision.RIGHT):
+            msg = 'This plan resolver requires an explicit {}'.format(
+                decision.suggest_plan_fix(decision.expected_choice))
+        elif decision.choice is None and decision.expected_choice is None:
+            left_decision = decision.suggest_plan_fix(Decision.LEFT)
+            right_decision = decision.suggest_plan_fix(Decision.RIGHT)
+            msg = 'This plan resolver cannot decide whether what to do for' \
+                ' resolving {}.'.format(decision.initiator)
+            if left_decision is not None and right_decision is not None:
+                msg += ' Please either add {} or {} in the plan'.format(
+                    left_decision,
+                    right_decision)
         elif decision.choice == Decision.BOTH:
             msg = 'cannot do both %s and %s' % (decision.left, decision.right)
         else:

--- a/e3/anod/context.py
+++ b/e3/anod/context.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import e3.log
-from e3.anod.action import (Build, BuildOrInstall, Checkout, CreateSource,
+from e3.anod.action import (Build, BuildOrDownload, Checkout, CreateSource,
                             CreateSourceOrDownload, CreateSources, Decision,
                             DownloadBinary, DownloadSource, GetSource, Install,
                             InstallSource, Root, Test, UploadBinaryComponent,
@@ -274,8 +274,8 @@ class AnodContext(object):
         if primitive == 'build':
             build_action = None
             for el in self.predecessors(result):
-                if isinstance(el, BuildOrInstall):
-                    el.set_decision(BuildOrInstall.BUILD, plan_line)
+                if isinstance(el, BuildOrDownload):
+                    el.set_decision(BuildOrDownload.BUILD, plan_line)
                     build_action = self[el.left]
             if build_action is None and isinstance(result, Build):
                 build_action = result
@@ -299,8 +299,8 @@ class AnodContext(object):
 
         elif primitive == 'install':
             for el in self.predecessors(result):
-                if isinstance(el, BuildOrInstall):
-                    el.set_decision(BuildOrInstall.INSTALL, plan_line)
+                if isinstance(el, BuildOrDownload):
+                    el.set_decision(BuildOrDownload.INSTALL, plan_line)
         return result
 
     def add_spec(self,
@@ -447,7 +447,7 @@ class AnodContext(object):
                     plan_args=None,
                     plan_line=plan_line,
                     force_source_deps=force_source_deps)
-                self.add_decision(BuildOrInstall,
+                self.add_decision(BuildOrDownload,
                                   result,
                                   build_action,
                                   download_action)
@@ -514,9 +514,9 @@ class AnodContext(object):
                     # subtree starting with an install node. In that case
                     # we expect the user to choose BUILD as decision.
                     dec = self.predecessors(child_action)[0]
-                    if isinstance(dec, BuildOrInstall):
+                    if isinstance(dec, BuildOrDownload):
                         dec.add_trigger(
-                            result, BuildOrInstall.BUILD,
+                            result, BuildOrDownload.BUILD,
                             plan_line if plan_line is not None
                             else 'unknown line')
 

--- a/tests/tests_e3/anod/action/main_test.py
+++ b/tests/tests_e3/anod/action/main_test.py
@@ -86,10 +86,10 @@ def test_initall():
 
     assert a_decision.get_decision() is None
 
-    a_decision.set_decision(action.Decision.RIGHT)
+    a_decision.set_decision(action.Decision.RIGHT, 'plan_line.txt:1')
     assert a_decision.get_decision() == 'download.my_source'
 
-    a_decision.set_decision(action.Decision.BOTH)
+    a_decision.set_decision(action.Decision.BOTH, 'plan_line.txt:2')
     assert a_decision.get_decision() is None
 
     boi_decision = action.BuildOrInstall(
@@ -97,7 +97,7 @@ def test_initall():
         left=build,
         right=download)
     assert boi_decision.get_decision() is None
-    boi_decision.set_decision(action.Decision.LEFT)
+    boi_decision.set_decision(action.Decision.LEFT, 'plan_line.txt:3')
     assert boi_decision.get_decision() == build.uid
 
 
@@ -127,7 +127,7 @@ def test_trigger():
 
     # Add a trigger on 'build'
     decision = action.Decision(root=root, left=build2, right=install2)
-    decision.add_trigger(build, action.Decision.LEFT)
+    decision.add_trigger(build, action.Decision.LEFT, 'my_plan_line')
 
     decision.apply_triggers(dag)
 
@@ -146,7 +146,7 @@ def test_trigger():
 
     # Set back to the expected choice and ask for another one
     decision.expected_choice = build2.uid
-    decision.set_decision(action.Decision.RIGHT)
+    decision.set_decision(action.Decision.RIGHT, 'my_other_plan_line')
     assert decision.get_decision() is None  # Decision.BOTH
 
     # Also change the expected choice to RIGHT

--- a/tests/tests_e3/anod/action/main_test.py
+++ b/tests/tests_e3/anod/action/main_test.py
@@ -121,12 +121,19 @@ def test_trigger():
     build_spec2.env = e3.env.Env()
     build2 = action.Build(anod_instance=build_spec2)
 
-    install2 = action.Install(anod_instance=build_spec2)
+    download2 = action.DownloadBinary(build_spec2)
+
+    install_spec2 = Spec(qualifier='', kind='install')
+    install_spec2.name = 'my_spec2'
+    install_spec2.env = e3.env.Env()
+    install2 = action.Install(install_spec2)
 
     dag.add_vertex(root)
+    dag.add_vertex(install2)
 
     # Add a trigger on 'build'
-    decision = action.Decision(root=root, left=build2, right=install2)
+    decision = action.BuildOrDownload(
+        root=install2, left=build2, right=download2)
     decision.add_trigger(build, action.Decision.LEFT, 'my_plan_line')
 
     decision.apply_triggers(dag)
@@ -151,4 +158,4 @@ def test_trigger():
 
     # Also change the expected choice to RIGHT
     decision.expected_choice = action.Decision.RIGHT
-    assert decision.get_expected_decision() == install2.uid
+    assert decision.get_expected_decision() == download2.uid

--- a/tests/tests_e3/anod/action/main_test.py
+++ b/tests/tests_e3/anod/action/main_test.py
@@ -92,7 +92,7 @@ def test_initall():
     a_decision.set_decision(action.Decision.BOTH, 'plan_line.txt:2')
     assert a_decision.get_decision() is None
 
-    boi_decision = action.BuildOrInstall(
+    boi_decision = action.BuildOrDownload(
         root=install,
         left=build,
         right=download)

--- a/tests/tests_e3/anod/context_data/spec10.anod
+++ b/tests/tests_e3/anod/context_data/spec10.anod
@@ -3,7 +3,23 @@ from e3.anod.spec import Anod
 
 class Spec10(Anod):
 
-    build_deps = [Anod.Dependency(name='spec3', require='build_tree')]
+    @property
+    def build_deps(self):
+        if 'build_tree_with_env' in self.parsed_qualifier:
+            return [
+                Anod.Dependency(name='spec3',
+                                build='x86_64-linux',
+                                host='x86-linux',
+                                target='arm-elf',
+                                qualifier='foo',
+                                require='build_tree')]
+        elif 'build_tree' in self.parsed_qualifier:
+            return [
+                Anod.Dependency(name='spec3',
+                                qualifier='foo',
+                                require='build_tree')]
+        else:
+            return [Anod.Dependency(name='spec3', require='installation')]
 
     @Anod.primitive()
     def build(self):

--- a/tests/tests_e3/anod/context_test.py
+++ b/tests/tests_e3/anod/context_test.py
@@ -98,6 +98,18 @@ class TestContext(object):
                  'mylinux.x86-linux.spec2.source_install.spec2-src',
                  'download.spec2-src'))
 
+    def test_add_anod_action2_no_source_resolver(self):
+        def no_resolver(action, decision):
+            return AnodContext.decision_error(action, decision)
+        ac = self.create_context()
+        ac.add_anod_action('spec2', primitive='build')
+        assert len(ac.tree) == 8, ac.tree.as_dot()
+
+        with pytest.raises(SchedulingError) as err:
+            ac.schedule(no_resolver)
+        assert 'This plan resolver cannot decide whether what to do' \
+            ' for resolving source_get.spec2-src.' in str(err)
+
     def test_add_anod_action3(self):
         # Simple spec with both install and build primitive and a package
         # declared
@@ -223,7 +235,51 @@ class TestContext(object):
         with pytest.raises(SchedulingError):
             ac.schedule(ac.always_download_source_resolver)
 
-    def test_add_anod_action11(self):
+    def test_add_anod_action11_build_tree_dep(self):
+        """Check build dependencies."""
+        ac = self.create_context()
+        ac.add_anod_action(
+            'spec10',
+            qualifier='build_tree',
+            primitive='build',
+            plan_line='myplan:1')
+
+        # we have a dep on spec3 build_pkg, we require an explicit call to
+        # build
+        with pytest.raises(SchedulingError) as err:
+            ac.schedule(ac.always_download_source_resolver)
+
+        assert 'This plan resolver requires an explicit' in str(err)
+        assert 'anod_build("spec3", qualifier="foo"' \
+            ', build="x86-linux")' in str(err)
+
+        ac.add_anod_action('spec3', qualifier='foo',
+                           primitive='install', plan_line='myplan:2')
+        with pytest.raises(SchedulingError) as err:
+            ac.schedule(ac.always_download_source_resolver)
+
+        assert 'explicit DownloadBinary decision made by myplan:2' in str(err)
+
+    def test_add_anod_action11_build_tree_dep_with_env(self):
+        """Check build dependencies."""
+        ac = self.create_context()
+        ac.add_anod_action(
+            'spec10',
+            qualifier='build_tree_with_env',
+            primitive='build',
+            plan_line='myplan:1')
+
+        # we have a dep on spec3 build_pkg, we require an explicit call to
+        # build
+        with pytest.raises(SchedulingError) as err:
+            ac.schedule(ac.always_download_source_resolver)
+
+        assert 'This plan resolver requires an explicit' in str(err)
+        assert 'anod_build("spec3", qualifier="foo",' \
+            ' build="x86_64-linux", host="x86-linux",' \
+            ' target="arm-elf")' in str(err)
+
+    def test_add_anod_action11_install_dep(self):
         """Check build dependencies."""
         ac = self.create_context()
         ac.add_anod_action('spec10', primitive='build', plan_line='myplan:1')
@@ -233,13 +289,14 @@ class TestContext(object):
         with pytest.raises(SchedulingError) as err:
             ac.schedule(ac.always_download_source_resolver)
 
-        assert '.build (expected)' in str(err)
+        assert 'Please either add anod_build("spec3", build="x86-linux") '\
+            'or anod_install("spec3", build="x86-linux")' \
+            ' in the plan' in str(err)
 
         ac.add_anod_action('spec3', primitive='install', plan_line='myplan:2')
-        with pytest.raises(SchedulingError) as err:
-            ac.schedule(ac.always_download_source_resolver)
 
-        assert 'explicit DownloadBinary decision made by myplan:2' in str(err)
+        # This call should not raise an exception
+        ac.schedule(ac.always_download_source_resolver)
 
     def test_add_anod_action12(self):
         """Check handling of duplicated source package."""

--- a/tests/tests_e3/anod/context_test.py
+++ b/tests/tests_e3/anod/context_test.py
@@ -226,7 +226,7 @@ class TestContext(object):
     def test_add_anod_action11(self):
         """Check build dependencies."""
         ac = self.create_context()
-        ac.add_anod_action('spec10', primitive='build')
+        ac.add_anod_action('spec10', primitive='build', plan_line='myplan:1')
 
         # we have a dep on spec3 build_pkg, we require an explicit call to
         # build
@@ -235,11 +235,11 @@ class TestContext(object):
 
         assert '.build (expected)' in str(err)
 
-        ac.add_anod_action('spec3', primitive='install')
+        ac.add_anod_action('spec3', primitive='install', plan_line='myplan:2')
         with pytest.raises(SchedulingError) as err:
             ac.schedule(ac.always_download_source_resolver)
 
-        assert 'is expected after' in str(err)
+        assert 'explicit DownloadBinary decision made by myplan:2' in str(err)
 
     def test_add_anod_action12(self):
         """Check handling of duplicated source package."""
@@ -315,7 +315,7 @@ class TestContext(object):
                    u'    anod_build("spec11", weathers="bar")']
         with open('plan.txt', 'w') as f:
             f.write('\n'.join(content))
-        myplan = plan.Plan({})
+        myplan = plan.Plan({}, plan_ext='.txt')
         myplan.load('plan.txt')
 
         # Execute the plan and create anod actions
@@ -474,10 +474,10 @@ class TestContext(object):
         content = [u'def myserver():',
                    u'    anod_build("spec3", weathers="A")',
                    u'    anod_build("spec3", weathers="B")']
-        with open('plan.txt', 'w') as f:
+        with open('plan.plan', 'w') as f:
             f.write('\n'.join(content))
         myplan = plan.Plan({})
-        myplan.load('plan.txt')
+        myplan.load('plan.plan')
 
         if not reject_duplicates:
             # Execute the plan and create anod actions

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
      pytest
      mock
      httpretty
+     pyyaml==3.13
      cov: pytest-cov
      codecov: codecov
 


### PR DESCRIPTION
Allow the plan scheduler to produce clear error message, including plan lines generating the conflicting actions.

To introduce a better plan error message it was needed to change the detection of plan_line that was not very usable. This might have some changes in plan checker on some plans. With the following plan

```
def build_a_and_test(spec):
    anod_build(a)
    anod_test(spec)

def entry_point():
    build_a_and_test('s1')
    build_a_and_test('s2')
```
The two calls to `anod_build(a)` are now considered duplicates.
