### PR TITLE
e3.main: add --console-logs option

### DIFF
--- a/e3/log.py
+++ b/e3/log.py
@@ -24,6 +24,8 @@ if sys.stdout.isatty():  # all: no cover (not used in production!)
 else:
     pretty_cli = False
 
+console_logs = None
+
 
 def progress_bar(it, **kwargs):
     """Create a tqdm progress bar.
@@ -160,6 +162,9 @@ def activate(
     # By default do not filter anything. What is effectively logged
     # will be defined by setting/unsetting handlers
     logging.getLogger('').setLevel(logging.DEBUG)
+    if console_logs:
+        stream_format = '{}: {}'.format(
+            console_logs, stream_format)
     fmt = logging.Formatter(stream_format, datefmt)
 
     # Set logging handlers

--- a/e3/main.py
+++ b/e3/main.py
@@ -11,6 +11,9 @@ The script will support by default the following switches::
     --log-file FILE
                  to redirect logs to a given file (this is independent from
                  verbose option
+    --console-logs
+                 disable color, progress bars, and redirect as much as
+                 possible to stdout, starting lines with the given prefix
 
 In addition, if the add_targets_options parameter is set to True
 when instantiating an object of class Main, the following switches
@@ -90,6 +93,11 @@ class Main(object):
             default=False,
             action="store_true",
             help='disable color and progress bars')
+        log_group.add_argument(
+            '--console-logs',
+            metavar="LINE_PREFIX",
+            help='disable color, progress bars, and redirect as much as'
+            ' possible to stdout, starting lines with the given prefix')
 
         if platform_args:
             plat_group = argument_parser.add_argument_group(
@@ -161,10 +169,13 @@ class Main(object):
 
         if not self.__log_handlers_set:
             # First set level of verbosity
-            if self.args.verbose:
+            if self.args.verbose or self.args.console_logs:
                 level = logging.DEBUG
             else:
                 level = self.args.loglevel
+
+            if self.args.console_logs:
+                e3.log.console_logs = self.args.console_logs
 
             e3.log.activate(level=level, filename=self.args.log_file,
                             e3_debug=self.args.verbose > 1)

--- a/tests/tests_e3/main/main_test.py
+++ b/tests/tests_e3/main/main_test.py
@@ -26,6 +26,23 @@ def test_mainprog():
     assert 'mymain' in p.out
 
 
+def test_mainprog_with_console_logs():
+    with open('mymain.py', 'w') as f:
+        f.write('\n'.join((
+            '#!/usr/bin/env python',
+            'from e3.main import Main',
+            'import os',
+            'm = Main(name="testmain")',
+            'm.parse_args()',
+            'import logging',
+            'logging.debug("this is an info line")',
+            'logging.debug("this is a debug line")')))
+    p = e3.os.process.Run(
+        [sys.executable, 'mymain.py', '--console-logs=mymain', '--nocolor'])
+    assert 'mymain: DEBUG    this is an info line\n' \
+        'mymain: DEBUG    this is a debug line' in p.out
+
+
 @pytest.mark.skipif(sys.platform in ('win32', 'sunos5'),
                     reason='Signal handler not set on windows.'
                            ' Bug in signal handling in solaris')


### PR DESCRIPTION
With --console-logs=PREFIX option logs will be emited to stdout, without
any color or progress bar and each log record will be prefixed by
"PREFIX: "

TN: S321-029