### PR TITLE
Set PyPI long description content type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
     author_email='info@adacore.com',
     description='E3 core. Tools and library for building and testing software',
     long_description=long_description,
+    long_description_content_type="text/markdown",
     namespace_packages=['e3'],
     use_2to3=True,
     classifiers=[


### PR DESCRIPTION
We're using README.md for the PyPI long description content,
with the new PyPI project we can now specify alternate format.