### PR TITLE
Set host CPU for Solaris cross to SPARC

### DIFF
--- a/e3/env.py
+++ b/e3/env.py
@@ -507,6 +507,8 @@ class AbstractBaseEnv(object):
             target_name, host = platform.rsplit('-', 1)
             if host == 'darwin':
                 host_cpu = 'x86_64'
+            elif host == 'solaris':
+                host_cpu = 'sparc'
             elif host.endswith('64'):
                 host = host[:-2]
                 host_cpu = 'x86_64'

--- a/tests/tests_e3/env/main_test.py
+++ b/tests/tests_e3/env/main_test.py
@@ -243,6 +243,10 @@ def test_from_platform_name():
     assert e.target.platform == 'x86_64-linux'
     assert e.build.platform == 'x86_64-linux'
     assert not e.is_cross
+    e = e3.env.BaseEnv.from_platform_name('avr-elf-solaris')
+    assert e.target.platform == 'avr-elf'
+    assert e.build.platform == 'sparc-solaris'
+    assert e.is_cross
 
     e = e3.env.BaseEnv.from_platform_name('what-linux-linux')
     assert e is None


### PR DESCRIPTION
Legacy cross compilers hosted on Solaris used SPARC hosts
(not the default x86).

For QA19-060