### PR TITLE
Rely on older pytest version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,12 @@ envlist = py37-cov,checkstyle
 
 [testenv]
 deps =
-     pytest
+     pytest<4.6.0
      mock
      httpretty
      pyyaml==3.13
-     cov: pytest-cov
+     cov: pytest-cov==2.5.1
+     cov: coverage==4.4.2
      codecov: codecov
 
 passenv = APPVEYOR* TRAVIS TRAVIS_* CI


### PR DESCRIPTION
New version crash at least with coverage