### PR TITLE
Fix explicit inclusion of source packages

### DIFF
--- a/e3/anod/context.py
+++ b/e3/anod/context.py
@@ -382,7 +382,7 @@ class AnodContext(object):
 
                 # Then one node for each source package
                 for sb in spec.source_pkg_build:
-                    if source_packages and sb not in source_packages:
+                    if source_packages and sb.name not in source_packages:
                         # This source package is defined in the spec but
                         # explicitly excluded in the plan
                         continue


### PR DESCRIPTION
When creating a CreateSources node with a subset of source packages
the parameter source_packages contain a list of source names and
not SourceBuilder objects.

TN: S613-023
(cherry picked from commit 8104290716fdc1301619555972a18d8693ec05df)