### PR TITLE
Disable checks during DAG creation on some operations

### DIFF
--- a/e3/collection/dag.py
+++ b/e3/collection/dag.py
@@ -607,8 +607,10 @@ class DAG(object):
                 # Node is pruned keep track of its predecessors
                 pruned_node_predecessors[node] = predecessors
             else:
-                # Node is kept
-                result.add_vertex(node, data, predecessors)
+                # Node is kept. Note that no check is needed as pruning
+                # operation cannot introduce a cycle.
+                result.update_vertex(node, data, predecessors,
+                                     enable_checks=False)
                 pruned_node_predecessors[node] = set([node])
                 if node in self.tags:
                     result.add_tag(node, self.tags[node])


### PR DESCRIPTION
* e3.anod.context.AnodContext.schedule: the operation can be considered
  as a pruning operation thus no cycle can be introduced
* e3.collection.dag.DAG.prune: pruning cannot introduce cycles by
  construction