### PR TITLE
Fail when a repository does not exist

### DIFF
--- a/e3/anod/context.py
+++ b/e3/anod/context.py
@@ -498,8 +498,10 @@ class AnodContext(object):
                     if sb.name == source_name:
                         for checkout in sb.checkout:
                             if checkout not in self.repo.repos:
-                                logger.warning(
-                                    'unknown repository %s', checkout)
+                                raise SchedulingError(
+                                    origin="add_spec",
+                                    message="unknown repository {}".format(
+                                        checkout))
                             co = Checkout(
                                 checkout, self.repo.repos.get(checkout))
                             add_action(co, result)

--- a/e3/electrolyt/run.py
+++ b/e3/electrolyt/run.py
@@ -100,10 +100,6 @@ class ElectrolytJob(Job):
     def do_checkout(self):
         """Get sources from vcs to sandbox vcs_dir."""
         repo_name = self.data.repo_name
-        if self.data.repo_data is None:
-            logger.error('%s configuration missing', repo_name)
-            self.__status = STATUS.failure
-            return
         repo_url = self.data.repo_data['url']
         repo_revision = self.data.repo_data['revision']
         repo_vcs = self.data.repo_data['vcs']

--- a/tests/tests_e3/anod/context_test.py
+++ b/tests/tests_e3/anod/context_test.py
@@ -28,6 +28,7 @@ class TestContext(object):
         asr.repos['spec1-git'] = 'spec1-git'
         asr.repos['spec8-git'] = 'spec8-git'
         asr.repos['spec2-git'] = 'spec2-git'
+        asr.repos['a-git'] = 'a-git'
         env = BaseEnv()
         env.set_build('x86-linux', 'rhes6', 'mylinux')
         ac = AnodContext(asr, default_env=env,

--- a/tests/tests_e3/anod/test_sandbox.py
+++ b/tests/tests_e3/anod/test_sandbox.py
@@ -474,8 +474,8 @@ def test_failure_status(git_specs_dir):
          '--specs-dir', local_spec_dir,
          '--plan', os.path.join(root_dir, 'test.plan'),
          sandbox_dir])
-    assert 'dummy-github configuration missing' in p.out, p.out
-    assert p.out.count('status=failure') == 7, p.out
+    assert 'add_spec: unknown repository dummy-github' in p.out, p.out
+    assert p.status == 1
 
 
 def test_sandbox_user_yaml(git_specs_dir):


### PR DESCRIPTION
Instead of generating a failure when the configuration for a
repository is not found it is better to crash completely when loading
the DAG. This will help detecting issues early during plan checks.

TN: S701-019