### PR TITLE
Consider that a token about to expire is invalid

### DIFF
--- a/e3/net/token.py
+++ b/e3/net/token.py
@@ -49,5 +49,10 @@ def is_valid(token):
     :rtype: bool
     """
     payload = get_payload(token)
+
+    # Given that we will use the token if valid, keep some margin and
+    # do not consider a token valid if it will be valid less than 5 min
+    deadline = utc_timestamp() + 5 * 60
+
     return payload.get('typ') == 'Bearer' and \
-        payload.get('exp', 0) > utc_timestamp()
+        payload.get('exp', 0) > deadline

--- a/tests/tests_e3/net/token/main_test.py
+++ b/tests/tests_e3/net/token/main_test.py
@@ -4,7 +4,7 @@ import base64
 import hashlib
 import json
 
-from e3.net.token import get_payload, is_valid
+from e3.net.token import get_payload, is_valid, utc_timestamp
 
 FUTURE_TIMESTAMP = 9999999999999
 
@@ -45,6 +45,11 @@ def test_valid_token():
         {u'typ': u'Bearer', u'exp': FUTURE_TIMESTAMP})
     assert is_valid(valid_token)
 
+    near_future = utc_timestamp() + 7 * 60
+    near_future_token = create_token(
+        {u'typ': u'Bearer', u'exp': near_future})
+    assert is_valid(near_future_token)
+
 
 def test_wrong_token_type():
     badtype_token = create_token(
@@ -56,6 +61,12 @@ def test_old_token():
     old_token = create_token(
         {u'typ': u'Bearer', u'exp': 1419064452})
     assert not is_valid(old_token)
+
+    # Verify that a token valid for less than 5 min will be considered invalid
+    expire_soon_date = utc_timestamp() + 4 * 60
+    expire_soon_token = create_token(
+        {u'typ': u'Bearer', u'exp': expire_soon_date})
+    assert not is_valid(expire_soon_token)
 
 
 def test_exception_pass():


### PR DESCRIPTION
If the token will valid less than 5 minutes consider that it is
invalid. When calling is_valid() we want to make sure that we will
be able to use the token for some operations before it becomes invalid.

Add two associated tests.
TN: R726-008