### PR TITLE
Don't raise an error if the same deps is added several time

### DIFF
--- a/e3/anod/context.py
+++ b/e3/anod/context.py
@@ -374,7 +374,8 @@ class AnodContext(object):
             :param dep_instance: the Anod instance loaded for that dependency
             :type dep_instance: Anod
             """
-            if dep.local_name in spec_instance.deps:
+            if dep.local_name in spec_instance.deps and \
+                    (spec_instance.deps[dep.local_name] != dep_instance):
                 raise AnodError(
                     origin='expand_spec',
                     message='The spec {} has two dependencies with the same '


### PR DESCRIPTION
When checking for collision in anod instance dependencies local_name,
do not raise an error if the same object is added several time. This is
a workaround for an issue occuring during addition of source actions

Part of S905-021