### PR TITLE
Equal sign is mandatory in --cov parameter

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands=
     {envpython} {toxinidir}/tests/gen-cov-config.py {toxinidir}/.coveragerc
     py.test --ignore=build -v \
     ci: --ci \
-    cov: --cov {envsitepackagesdir}/e3 --cov-report= --cov-fail-under=0 \
+    cov: --cov={envsitepackagesdir}/e3 --cov-report= --cov-fail-under=0 \
     []
     cov: {envpython} {toxinidir}/tests/fix-coverage-paths.py \
     cov:     {envsitepackagesdir} {toxinidir}/.coverage


### PR DESCRIPTION
(cherry picked from commit 6b9b084ddceb6f7093685d5efeccf8fdd031645e)