### PR TITLE
Fix typos

### DIFF
--- a/e3/anod/action/__init__.py
+++ b/e3/anod/action/__init__.py
@@ -393,7 +393,7 @@ class Decision(Action):
     :ivar expected_choice: If not None, the choice implicitly made
         by the way the specs involved in the decision are written.
         In practice, this attribute records the constraints we have
-        in terms of the the choices in the plan which are valid.
+        in terms of the choices in the plan which are valid.
     :ivar triggers: A list of actions that, if present in a DAG
         being created while scheduling the plan (from which this
         Decision originates), causes a specific choice to be expected

--- a/e3/electrolyt/host.py
+++ b/e3/electrolyt/host.py
@@ -87,7 +87,7 @@ class HostDB(object):
 
         Additional keys for a host entry will be considered as additional data
 
-        :param filename: path the the yaml file
+        :param filename: path the yaml file
         :type filename: str
         """
         with open(filename, 'rb') as fd:

--- a/e3/fingerprint.py
+++ b/e3/fingerprint.py
@@ -40,7 +40,7 @@ class Fingerprint(object):
     """Fingerprint class.
 
     :ivar elements: a dictionary containing the checksum/id for each element
-        part of of the fingerprint. The key a string identifying the
+        part of the fingerprint. The key a string identifying the
         element.
     """
 

--- a/e3/os/windows/fs.py
+++ b/e3/os/windows/fs.py
@@ -263,7 +263,7 @@ class NTFile(object):
         """Return path in which the file can move safely for deletion.
 
         On NTFS filesystem we are sure that the path is unique and thus
-        that no existing file can exist at that that location.
+        that no existing file can exist at that location.
 
         :return: a path
         :rtype: unicode

--- a/tests/tests_e3/job/scheduling_test.py
+++ b/tests/tests_e3/job/scheduling_test.py
@@ -168,7 +168,7 @@ class TestScheduler(object):
 
         Scheme in which if a job predecessor "fails" then job is skipped
         In order to do that get_job and collect should have access to
-        common data. Note that that scheduler ensure that these functions
+        common data. Note that scheduler ensure that these functions
         are called sequentially.
         """
         class SchedulerContext(object):


### PR DESCRIPTION
Detected by running:

git grep  -H " \([[:alpha:]][[:alpha:]]\+\) \1[[:space:]]"