### PR TITLE
Fix issue with extraction of tarfile with readonly directories

### DIFF
--- a/e3/archive.py
+++ b/e3/archive.py
@@ -219,7 +219,14 @@ def unpack_archive(filename,
                                 return True
                         return False
                     dirs = []
+
+                    # IMPORTANT: don't use the method extract. Always use the
+                    # extractall function. Indeed extractall will set file
+                    # permissions only once all selected members are unpacked.
+                    # Using extract can lead to permission denied for example
+                    # if a read-only directory is created.
                     if selected_files:
+                        member_list = []
                         for tinfo in fd:
                             if is_match(tinfo.name, selected_files) or \
                                     tinfo.name.startswith(tuple(dirs)):
@@ -227,14 +234,16 @@ def unpack_archive(filename,
                                 if tinfo.isdir() and \
                                         not tinfo.name.startswith(tuple(dirs)):
                                     dirs.append(tinfo.name)
-                                fd.extract(tinfo, path=tmp_dest)
+                                member_list.append(tinfo)
+
                         if check_selected:
                             raise ArchiveError(
                                 'unpack_archive',
                                 'Cannot untar %s ' % filename)
+
+                        fd.extractall(path=tmp_dest, members=member_list)
                     else:
-                        for tinfo in fd:
-                            fd.extract(tinfo, path=tmp_dest)
+                        fd.extractall(path=tmp_dest)
 
             except tarfile.TarError as e:
                 raise ArchiveError(

--- a/e3/fs.py
+++ b/e3/fs.py
@@ -301,6 +301,67 @@ def mv(source, target):
 
     :raise FSError: if an error occurs
     """
+    def move_file(src, dst):
+        """Reimplementation of shutil.move.
+
+        The implementation follows shutil.move from the standard library.
+        The only difference is that we use e3.fs.rm function instead of
+        rmtree. This ensure moving a directory with read-only files will
+        work.
+        """
+        def same_file(src, dst):
+            if hasattr(os.path, 'samefile'):
+                try:
+                    return os.path.samefile(src, dst)
+                except OSError:
+                    return False
+            return (os.path.normcase(os.path.abspath(src)) ==
+                    os.path.normcase(os.path.abspath(dst)))
+
+        def basename(path):
+            sep = os.path.sep + (os.path.altsep or '')
+            return os.path.basename(path.rstrip(sep))
+
+        def destinsrc(src, dst):
+            src = os.path.abspath(src)
+            dst = os.path.abspath(dst)
+            if not src.endswith(os.path.sep):
+                src += os.path.sep
+            if not dst.endswith(os.path.sep):
+                dst += os.path.sep
+            return dst.startswith(src)
+
+        real_dst = dst
+        if os.path.isdir(dst):
+            if same_file(src, dst):
+                # We might be on a case insensitive filesystem,
+                # perform the rename anyway.
+                os.rename(src, dst)
+                return
+
+            real_dst = os.path.join(dst, basename(src))
+            if os.path.exists(real_dst):
+                raise FSError(
+                    "Destination path '%s' already exists" % real_dst)
+        try:
+            os.rename(src, real_dst)
+        except OSError:
+            if os.path.islink(src):
+                linkto = os.readlink(src)
+                os.symlink(linkto, real_dst)
+                os.unlink(src)
+            elif os.path.isdir(src):
+                if destinsrc(src, dst):
+                    raise FSError(
+                        "Cannot move a directory '%s' into itself"
+                        " '%s'." % (src, dst))
+                shutil.copytree(src, real_dst, symlinks=True)
+                rm(src, recursive=True)
+            else:
+                shutil.copy2(src, real_dst)
+                rm(src)
+        return real_dst
+
     if isinstance(source, basestring):
         logger.debug('mv %s %s', source, target)
     else:
@@ -315,7 +376,12 @@ def mv(source, target):
             raise FSError(origin='mv',
                           message='cannot find files matching "%s"' % source)
         elif nb_files == 1:
-            e3.os.fs.mv(file_list[0], target)
+            source = file_list[0]
+            if os.path.isdir(source) and os.path.isdir(target):
+                move_file(source,
+                          os.path.join(target, os.path.basename(source)))
+            else:
+                move_file(source, target)
         elif not os.path.isdir(target):
             # More than one file to move but the target is not a directory
             raise FSError('mv', '%s should be a directory' % target)
@@ -323,7 +389,7 @@ def mv(source, target):
             for f in file_list:
                 f_dest = os.path.join(target, os.path.basename(f))
                 e3.log.debug('mv %s %s', f, f_dest)
-                shutil.move(f, f_dest)
+                move_file(f, f_dest)
     except Exception as e:
         logger.error(e)
         raise FSError(origin='mv', message=str(e)), None, sys.exc_traceback

--- a/tests/tests_e3/archive/main_test.py
+++ b/tests/tests_e3/archive/main_test.py
@@ -260,3 +260,18 @@ def test_empty():
     e3.archive.unpack_archive(os.path.join('dest', 'pkg.zip'),
                               'result', remove_root_dir=True)
     assert os.listdir('result') == []
+
+
+def test_archive_with_readonly_dir():
+    """Test unpack of archive with read-only directory."""
+    e3.fs.mkdir('from')
+    e3.fs.mkdir('dest')
+    e3.fs.mkdir('result')
+    e3.fs.mkdir('from/readonly_dir')
+    e3.os.fs.touch('from/readonly_dir/file.txt')
+    e3.os.fs.chmod('u=rx,go=rx', 'from/readonly_dir')
+    e3.archive.create_archive('pkg.tar.gz', os.path.abspath('from'), 'dest')
+    e3.os.fs.chmod('urwx', 'from/readonly_dir')
+    e3.archive.unpack_archive(os.path.join('dest', 'pkg.tar.gz'),
+                              'result', remove_root_dir=True)
+    assert os.path.isfile(os.path.join('result', 'readonly_dir', 'file.txt'))


### PR DESCRIPTION
* Fix issue during extraction itself during which permissions
  should be set only once all members are archived
* Fix issue during mv in case remove_root_dir is set

Part of SA28-017