### PR TITLE
improve error message when a plan has an install that should be a build

### DIFF
--- a/e3/anod/context.py
+++ b/e3/anod/context.py
@@ -438,7 +438,10 @@ class AnodContext(object):
                 # spec has no binary package to download.
                 raise SchedulingError(
                     "error in plan at {}: "
-                    "install should be replaced by build".format(plan_line))
+                    "Cannot install `{}' because this spec does not produce "
+                    "a package; check you are using the appropriate "
+                    "qualifiers or replace it by a build?"
+                    .format(plan_line, name))
             # Case in which we have an install dependency but no install
             # primitive. In that case the real dependency is a build tree
             # dependency. In case there is no build primitive and no

--- a/tests/tests_e3/anod/context_test.py
+++ b/tests/tests_e3/anod/context_test.py
@@ -107,8 +107,9 @@ class TestContext(object):
             ac.add_anod_action('spec2', primitive='install',
                                plan_args={}, plan_line="install_plan.txt:2")
         except SchedulingError as err:
-            assert 'error in plan at install_plan.txt:2: install should ' \
-                'be replaced by build' in str(err)
+            assert "error in plan at install_plan.txt:2: " \
+                "Cannot install `spec2' because this spec does not " \
+                "produce a package" in str(err)
 
     def test_add_anod_action2_no_source_resolver(self):
         def no_resolver(action, decision):


### PR DESCRIPTION
The new error message gives a bit more information, and tries to provide
more possible solutions to the issue, hoping that this will help users
with less experience around Anod specs and electrolyt plans.

Seen while working on T107-003.

Additional note that's not in this commit's revision log: Please feel free to suggest a better error message!