### PR TITLE
Avoid collision on s3 bucket receiving events

### DIFF
--- a/e3/event/__init__.py
+++ b/e3/event/__init__.py
@@ -18,6 +18,17 @@ from e3.fs import mkdir
 logger = e3.log.getLogger('event')
 
 
+def unique_id():
+    """Return a random globally unique id.
+
+    :return: an id
+    :rtype: str
+    """
+    # Using clock_seq ensures that the uid of the event has at least
+    # microsecond precision.
+    return str(uuid.uuid1(clock_seq=int(1000 * time.time())))
+
+
 class Event(object):
     """Event class for notifying external services.
 
@@ -52,8 +63,7 @@ class Event(object):
         object.__setattr__(self, '_closed', False)
         object.__setattr__(self, '_formatters', {})
 
-        self.uid = uid if uid is not None else \
-            str(uuid.uuid1(clock_seq=int(1000 * time.time())))
+        self.uid = uid if uid is not None else unique_id()
         self.name = name
         self.begin_time = time.time()
         self.end_time = None
@@ -174,7 +184,8 @@ class Event(object):
                   'attachments': self._attachments,
                   'closed': self._closed}
         mkdir(event_dir)
-        json_filename = os.path.join(event_dir, self.uid + '.json')
+        json_filename = os.path.join(
+            event_dir, "%s-%s.json" % (self.uid, unique_id()))
         with open(json_filename, 'w') as fd:
             json.dump(result, fd)
         return json_filename

--- a/e3/event/handler/s3.py
+++ b/e3/event/handler/s3.py
@@ -2,9 +2,10 @@ from __future__ import absolute_import
 import mimetypes
 import tempfile
 import json
+
 from contextlib import closing
 
-from e3.event import EventHandler
+from e3.event import EventHandler, unique_id
 from e3.fs import rm
 from e3.os.process import Run
 from e3.sys import python_script
@@ -70,9 +71,14 @@ class S3Handler(EventHandler):
                 tempfile_name = fd.name
                 json.dump(s3_event, fd)
 
+            # Note that an event can be sent several times with a different
+            # status. As a consequence the target url in s3 should be different
+            # for call to send.
             success = s3_cp(
                 tempfile_name,
-                "%s/%s" % (self.event_s3_url, event.uid + '.s3'))
+                "%s/%s-%s.s3" %
+                (self.event_s3_url, event.uid, unique_id()))
+
             if not success:
                 return False
             else:


### PR DESCRIPTION
A same events can be sent several times with a different status
(running, failed, ...).