### PR TITLE
Fix test_svn_checkout on servers using old git version

### DIFF
--- a/e3/vcs/git.py
+++ b/e3/vcs/git.py
@@ -128,6 +128,11 @@ class GitRepository(object):
         e3.fs.mkdir(self.working_tree)
         self.git_cmd(['init', '-q'])
 
+        # Git version 1.8.3.1 might crash when calling "git stash" when
+        # .git/logs/refs is not created. Recent versions of git do not
+        # exhibit this problem
+        e3.fs.mkdir(os.path.join(self.working_tree, '.git', 'logs', 'refs'))
+
         if url is not None:
             self.git_cmd(['remote', 'add', remote, url])
 


### PR DESCRIPTION
On servers using old git version such as 1.8.3.1 we have an issue
when trying to switch from SVN to Git

The calls to:

  git init -q
  git remote add <name> <path>
  git fetch -f <name> <branch>:<ref>

do not create the directory .git/logs/refs that git stash expect

As a workaround this patch always create the directory when
initializing a Git repository

TN: T117-028