### PR TITLE
Improve plan checker error when missing explicit build

### DIFF
--- a/e3/anod/context.py
+++ b/e3/anod/context.py
@@ -642,8 +642,18 @@ class AnodContext(object):
         """
         if decision.choice is None and decision.expected_choice in (
                 Decision.LEFT, Decision.RIGHT):
-            msg = 'This plan resolver requires an explicit {}'.format(
-                decision.suggest_plan_fix(decision.expected_choice))
+
+            if decision.expected_choice == BuildOrDownload.BUILD:
+                msg = 'A spec in the plan has a build_tree dependency' \
+                    ' on {spec}. Either explicitly add the line {plan_line}' \
+                    ' or change the dependency to set' \
+                    ' require="installation" if possible'.format(
+                        spec=action.data.name,
+                        plan_line=decision.suggest_plan_fix(
+                            decision.expected_choice))
+            else:
+                msg = 'This plan resolver requires an explicit {}'.format(
+                    decision.suggest_plan_fix(decision.expected_choice))
         elif decision.choice is None and decision.expected_choice is None:
             left_decision = decision.suggest_plan_fix(Decision.LEFT)
             right_decision = decision.suggest_plan_fix(Decision.RIGHT)

--- a/tests/tests_e3/anod/context_test.py
+++ b/tests/tests_e3/anod/context_test.py
@@ -261,7 +261,7 @@ class TestContext(object):
         with pytest.raises(SchedulingError) as err:
             ac.schedule(ac.always_download_source_resolver)
 
-        assert 'This plan resolver requires an explicit' in str(err)
+        assert 'has a build_tree dependency on spec3' in str(err)
         assert 'anod_build("spec3", qualifier="foo"' \
             ', build="x86-linux")' in str(err)
 
@@ -286,7 +286,7 @@ class TestContext(object):
         with pytest.raises(SchedulingError) as err:
             ac.schedule(ac.always_download_source_resolver)
 
-        assert 'This plan resolver requires an explicit' in str(err)
+        assert 'has a build_tree dependency on spec3' in str(err)
         assert 'anod_build("spec3", qualifier="foo",' \
             ' build="x86_64-linux", host="x86-linux",' \
             ' target="arm-elf")' in str(err)


### PR DESCRIPTION
When the plan has a build_tree dependency on a spec and the resolver
configuration require an explicit build in the plan mention the two
possible alternatives:

- add the explicit build in the plan
- or modify the dependency on the spec

TN: SA22-006