### PR TITLE
Adjust status emited in case of predecessor failure

### DIFF
--- a/e3/job/walk.py
+++ b/e3/job/walk.py
@@ -269,7 +269,7 @@ class Walk(object):
 
             return self.create_skipped_job(uid, data, predecessors,
                                            force_fail, notify_end,
-                                           status=ReturnValue.failure)
+                                           status=ReturnValue.force_fail)
 
         if self.should_execute_action(uid, prev_fingerprint,
                                       self.new_fingerprints[uid]):

--- a/tests/tests_e3/job/walk_test.py
+++ b/tests/tests_e3/job/walk_test.py
@@ -318,10 +318,10 @@ class TestWalk(object):
         job = c.saved_jobs['2']
         assert isinstance(job, EmptyJob)
         assert job.should_skip is True
-        assert job.status == ReturnValue.failure
+        assert job.status == ReturnValue.force_fail
 
         assert c.job_status == {'1.bad': ReturnValue(1),
-                                '2': ReturnValue.failure}
+                                '2': ReturnValue.force_fail}
         assert c.requeued == {}
 
         # In the situation where we are using fingerprints,
@@ -339,10 +339,10 @@ class TestWalk(object):
             job = r2.saved_jobs['2']
             assert isinstance(job, EmptyJob)
             assert job.should_skip is True
-            assert job.status == ReturnValue.failure
+            assert job.status == ReturnValue.force_fail
 
             assert r2.job_status == {'1.bad': ReturnValue(1),
-                                     '2': ReturnValue.failure}
+                                     '2': ReturnValue.force_fail}
             assert r2.requeued == {}
 
     def test_job_not_ready_then_ok(self, walk_class, setup_sbx):
@@ -884,7 +884,7 @@ def test_job_depending_on_job_with_no_predicted_fingerprint_failed(setup_sbx):
     job = r1.saved_jobs['2']
     assert isinstance(job, EmptyJob)
     assert job.should_skip is True
-    assert job.status == ReturnValue.failure
+    assert job.status == ReturnValue.force_fail
 
     # Check that no job was requeued.
     assert r1.requeued == {}


### PR DESCRIPTION
force_fail should be set instead of failure. This allow to make the
distinctiion between root cause failures and subsequent ones.

Part of SC03-056