### PR TITLE
Add new BuildSpace.exists method

### DIFF
--- a/e3/anod/buildspace.py
+++ b/e3/anod/buildspace.py
@@ -35,6 +35,27 @@ class BuildSpace(object):
         self.root_dir = os.path.abspath(root_dir)
         self.initialized = False
 
+    def exists(self):
+        """Return True if the build space exists on disk.
+
+        This function just checks the contents of self.root_dir,
+        and verifies that it appears to be a build space.
+        It does so, irrespective of whether self.initialize
+        is True or not.
+
+        :return: True if self.root_dir is a buildspace, False otherwise.
+        :rtype: bool
+        """
+        # Start by verifying that the file used as build space markers
+        # exists.
+        if not os.path.isfile(os.path.join(self.root_dir, '.buildspace')):
+            return False
+        # Next, verify that all the necessary directories exist as well.
+        for d in self.DIRS:
+            if not os.path.isdir(self.subdir(name=d)):
+                return False
+        return True
+
     @property
     def dirs(self):
         return self.directory_mapping.values()

--- a/tests/tests_e3/anod/test_buildspace.py
+++ b/tests/tests_e3/anod/test_buildspace.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import os
 
 from e3.anod.buildspace import BuildSpace
-from e3.fs import mkdir
+from e3.fs import mkdir, rm
 from e3.os.fs import touch
 
 import pytest
@@ -46,3 +46,34 @@ def test_reset_tmp_dir():
     assert os.path.exists(marker)
     bs.create()
     assert not os.path.exists(marker)
+
+
+def test_build_space_exists():
+    """Test the BuildSpace.exists method."""
+    bs_name = os.path.abspath('foo')
+    bs = BuildSpace(bs_name)
+
+    # First, verify the behavior when the buildspace directory
+    # doesn't even exist.
+    assert not os.path.exists(bs_name), bs_name
+    assert bs.exists() is False
+
+    # Next, create the directory, but without anything in it.
+    # In particular, the marker file isn't present, so
+    # is_buildspace should still return False for that directory.
+    mkdir(bs_name)
+    assert bs.exists() is False
+
+    # Create the buildspace, and then verify that is_buildspace
+    # then returns True.
+    bs.create()
+    assert bs.exists() is True
+
+    # Verify that we also return False if one of the subdirectories
+    # is missing. To do that, first verify that the subdirectory
+    # we picked does exist, then delete it, before observing
+    # whether BuildSpace.exists now return False or not.
+    one_subdir = bs.subdir(bs.DIRS[0])
+    assert os.path.isdir(one_subdir)
+    rm(one_subdir, recursive=True)
+    assert bs.exists() is False


### PR DESCRIPTION
This method allows users to determine whether a build space
(still?) exists or not. One possible application of that method
is in electrolyt, where we can take the existance of an action's
build space (or lack thereof) into consideration when deciding
whether to execute that action or not.

TN: S114-025