### PR TITLE
Sanitize Env.set_env input to handle bad user input

### DIFF
--- a/src/e3/env.py
+++ b/src/e3/env.py
@@ -240,6 +240,14 @@ class AbstractBaseEnv(object, metaclass=abc.ABCMeta):
         :param host: string as passed to --host
         :param target: string as passed to --target
         """
+        # Sanitize the input
+        if host is not None and target == host:
+            # Set target to None if it should inherit the value from host
+            target = None
+        if build is not None and host == build:
+            # Set host to None if it should inherit the value from build
+            host = None
+
         saved_build = self.build
         saved_host = self.host
         saved_target = self.target

--- a/tests/tests_e3/env/main_test.py
+++ b/tests/tests_e3/env/main_test.py
@@ -117,6 +117,16 @@ def test_set_env():
     e.set_env("x86-linux,rhEs5", "x86_64-linux,debian7", "host")
     assert e.target.platform == "x86_64-linux"
 
+    # Special case to handle user input errors
+    e.set_env("x86-linux,rhEs5", "x86-linux,rhEs5", "x86-windows")
+    assert e.build == e.host
+
+    e.set_env("x86-linux,rhEs5", "x86-windows", "x86-windows")
+    assert e.host == e.target
+
+    e.set_env("x86-linux,rhEs5", "x86-linux,rhEs5", "x86-linux,rhEs5")
+    assert e.build == e.host == e.target
+
 
 def test_cmd_triplet():
     if e3.env.Env().build.platform == "x86-linux":


### PR DESCRIPTION
When a user pass the same value for build and host (or host and target)
Env.set_env currently creates different Platform objects and then
checks such as:

    if env.build != env.host: ...

have a surprising behaviour for users.

Let's handle this case in set_env, which is called when reading a
plan.

TN: R502-041