### PR TITLE
Use py3 features

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
     * e3.anod.context.AnodContext.add_spec ``env`` and ``primitive``
   * some attribute have been replaced by properties to avoid being marked as Optional
     * e3.anod.spec.Anod ``build_space``
+* Deprecate e3.decorator.memoize, use functools.lru_cache instead
 
 # Version 22.0.0 (2020-03-13)
 

--- a/src/e3/anod/checkout.py
+++ b/src/e3/anod/checkout.py
@@ -5,11 +5,11 @@ import json
 import os
 import tempfile
 from contextlib import closing
-from subprocess import PIPE
 from typing import TYPE_CHECKING
 
 import e3.log
 from e3.anod.status import ReturnValue
+from e3.os.process import PIPE
 from e3.fs import VCS_IGNORE_LIST, get_filetree_state, rm, sync_tree
 from e3.vcs.git import GitError, GitRepository
 from e3.vcs.svn import SVNError, SVNRepository

--- a/src/e3/anod/deps.py
+++ b/src/e3/anod/deps.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import collections
+import collections.abc
 from typing import TYPE_CHECKING
 
 import e3.anod.error
@@ -20,7 +20,7 @@ class BuildVar:
         :param name: name of the variable
         :param value: variable value
         """
-        assert isinstance(value, collections.Hashable)
+        assert isinstance(value, collections.abc.Hashable)
         self.name = name
         self.value = value
         self.kind = "var"

--- a/src/e3/anod/loader.py
+++ b/src/e3/anod/loader.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import imp
 import inspect
 import os
 import sys
+import types
 
 import yaml
 from typing import TYPE_CHECKING
@@ -171,7 +171,7 @@ class AnodModule:
 
         # Create a new module
         mod_name = "anod_" + self.name
-        anod_module = imp.new_module(mod_name)
+        anod_module = types.ModuleType(mod_name)
 
         try:
             with open(self.path) as fd:

--- a/src/e3/decorator.py
+++ b/src/e3/decorator.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from functools import partial
 
 from typing import TYPE_CHECKING
+from warnings import warn
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Dict
@@ -85,6 +86,11 @@ class memoize:
         """
         self.func = func
         self.cache: Dict[tuple, Any] = {}
+        warn(
+            "this decorator will be removed in a later version of e3-core, "
+            "please use functools.lru_cache instead",
+            category=DeprecationWarning,
+        )
 
     def __call__(self, *args, **kwargs) -> Any:
         """Return the cache value if exist, else call func."""

--- a/src/e3/electrolyt/plan.py
+++ b/src/e3/electrolyt/plan.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import ast
-import imp
 import inspect
+import types
 from functools import partial
 from typing import TYPE_CHECKING
 
@@ -44,7 +44,7 @@ class Plan:
             detect whether a specific frame is in a plan or in our code. See
             PlanContext._add_action
         """
-        self.mod = imp.new_module("_anod_plan_")
+        self.mod = types.ModuleType("_anod_plan_")
 
         # Some additional user symbols
         for k, v in data.items():

--- a/src/e3/net/http.py
+++ b/src/e3/net/http.py
@@ -122,7 +122,13 @@ class HTTPSession:
                 ),
             )
 
-    def request(self, method: str, url: str, **kwargs):
+    def request(
+        self,
+        method: str,
+        url: str,
+        data_streams: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ):
         """Send a request.
 
         See requests Session.request function.
@@ -140,12 +146,6 @@ class HTTPSession:
         headers one modified.
         """
         error_msgs = []
-        data_streams = None
-
-        # Keep data_streams apart as it is not an argument to request
-        if "data_streams" in kwargs:
-            data_streams = kwargs["data_streams"]
-            del kwargs["data_streams"]
 
         for base_url in list(self.base_urls):
             if self.last_base_url != base_url:

--- a/src/e3/os/process.py
+++ b/src/e3/os/process.py
@@ -23,10 +23,22 @@ import e3.log
 from e3.os.fs import which
 
 if TYPE_CHECKING:
-    from typing import IO, Any, List, NoReturn, Optional, Union
+    from typing import cast, Any, IO, List, Literal, NoReturn, Optional, Union
 
     CmdLine = List[str]
     AnyCmdLine = Union[List[CmdLine], CmdLine]
+    STDOUT_VALUE = Literal[-1]
+    PIPE_VALUE = Literal[-2]
+    DEVNULL_VALUE = Literal[-3]
+
+    # Make STDOUT subprocess constant visible in e3.os.process
+    STDOUT = cast(STDOUT_VALUE, subprocess.STDOUT)
+    PIPE = cast(PIPE_VALUE, subprocess.PIPE)
+    DEVNULL = cast(DEVNULL_VALUE, subprocess.DEVNULL)
+else:
+    STDOUT = subprocess.STDOUT
+    PIPE = subprocess.PIPE
+    DEVNULL = subprocess.DEVNULL
 
 logger = e3.log.getLogger("os.process")
 
@@ -36,9 +48,6 @@ CMD_LOGGER_NAME = "os.process.cmdline"
 
 cmdlogger = e3.log.getLogger(CMD_LOGGER_NAME)
 
-# Make STDOUT subprocess constant visible in e3.os.process
-STDOUT = subprocess.STDOUT
-PIPE = subprocess.PIPE
 
 # Use psutil.Popen when available to get psutil.Process properties and
 # methods available in Run.internal
@@ -215,9 +224,9 @@ class Run:
         self,
         cmds: AnyCmdLine,
         cwd: Optional[str] = None,
-        output: Union[int, str, IO, None] = PIPE,
-        error: Union[int, str, IO, None] = STDOUT,
-        input: Union[int, str, IO, None] = None,
+        output: Union[STDOUT_VALUE, DEVNULL_VALUE, PIPE_VALUE, str, IO, None] = PIPE,
+        error: Union[STDOUT_VALUE, DEVNULL_VALUE, PIPE_VALUE, str, IO, None] = STDOUT,
+        input: Union[DEVNULL_VALUE, PIPE_VALUE, str, IO, None] = None,
         bg: bool = False,
         timeout: Optional[int] = None,
         env: dict = None,

--- a/src/e3/platform_db/__init__.py
+++ b/src/e3/platform_db/__init__.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import abc
 from collections import namedtuple
+from functools import lru_cache
 
-import e3.decorator
 import e3.log
 import stevedore
 
@@ -48,7 +48,7 @@ class AmberCPUSupport(PlatformDBPlugin):
         )
 
 
-@e3.decorator.memoize
+@lru_cache()
 def get_knowledge_base():
     """Load the knowledge base, including all content from plugins.
 

--- a/tests/tests_e3/platform_db/main_test.py
+++ b/tests/tests_e3/platform_db/main_test.py
@@ -19,8 +19,14 @@ def test_knownledge_base():
     try:
         stevedore.ExtensionManager.ENTRY_POINT_CACHE["e3.platform_db"].append(mydb_ep)
 
+        db = get_knowledge_base()
+        # Check that the new amber CPU has been inserted
+        for cpu_name in ("amber23", "amber25"):
+            assert cpu_name not in db.cpu_info
+
         # Force a reload of the platform_db knowledge base
-        db = get_knowledge_base(reset_cache=True)
+        get_knowledge_base.cache_clear()
+        db = get_knowledge_base()
 
         # Check that the new amber CPU has been inserted
         for cpu_name in ("amber23", "amber25"):

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,9 @@ commands =
 
 [pytest]
 addopts = --failed-first
+markers =
+    git: git needs to be installed to run these tests
+    svn: svn needs to be installed to run these tests
 
 [flake8]
 exclude = .git,__pycache__,build,dist,.tox


### PR DESCRIPTION
Modernize e3-core code:

- remove some kwargs hacks that are not needed anymore
- recommend functools.lru_cache instead of e3.decorator.memoize
- address deprecation warnings