### PR TITLE
Simplify code to avoid mypy false positive

### DIFF
--- a/src/e3/electrolyt/plan.py
+++ b/src/e3/electrolyt/plan.py
@@ -146,7 +146,7 @@ class PlanContext:
             self.plan = plan
             new = self.stack[-1].copy(build=build, host=host, target=target)
 
-            if new.enabled and not enabled:
+            if not enabled:
                 # we are in a block with enabled=False set, disable all
                 # lines in that block
                 new.enabled = enabled


### PR DESCRIPTION
mypy wrongly detect unreachable code here, simplify it to avoid
this false positive. This sets the value for new.enabled a little
too often but this should have only very minor performance impact.