### PR TITLE
Reduce log noise when using a sandbox

### DIFF
--- a/src/e3/anod/sandbox/__init__.py
+++ b/src/e3/anod/sandbox/__init__.py
@@ -136,7 +136,7 @@ class SandBox:
         # Expand ~, environment variables and eliminate symbolic links
         self.__specs_dir = os.path.realpath(os.path.expandvars(os.path.expanduser(d)))
         self.is_alternate_specs_dir = True
-        logger.info("using alternate specs dir %s", d)
+        logger.debug("using alternate specs dir %s", d)
 
     def create_dirs(self) -> None:
         """Create all required sandbox directories."""

--- a/tests/tests_e3/anod/test_sandbox.py
+++ b/tests/tests_e3/anod/test_sandbox.py
@@ -599,6 +599,7 @@ def test_sandbox_user_yaml(git_specs_dir):
     p = e3.os.process.Run(
         [
             "e3-sandbox",
+            "-v",
             "exec",
             "--plan",
             os.path.join(sandbox_dir, "test.plan"),


### PR DESCRIPTION
The message "using alternate specs dir" emitted too often now that
is it encouraged to use alternate specs dir. Make it a DEBUG record.