### PR TITLE
Introduce e3 configuration file

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -43,3 +43,9 @@ ignore_missing_imports = True
 
 [mypy-tqdm.*]
 ignore_missing_imports = True
+
+[mypy-tomlkit.*]
+ignore_missing_imports = True
+
+[mypy-typeguard.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     "stevedore>1.20.0",
 ]
 
-extras_require = {}
+extras_require = {"config": ["tomlkit", "typeguard"]}
 
 for p in ("darwin", "linux", "linux2", "win32"):
     platform_string = ":sys_platform=='%s'" % p

--- a/src/e3/config.py
+++ b/src/e3/config.py
@@ -1,0 +1,142 @@
+"""Read e3 config file."""
+from __future__ import annotations
+from dataclasses import fields, dataclass
+
+from typing import TYPE_CHECKING, get_type_hints, ClassVar
+
+try:
+    from typeguard import check_type
+
+    CONFIG_CHECK_TYPE = True
+except ImportError:  # defensive code
+    CONFIG_CHECK_TYPE = False
+
+
+import logging
+import os
+
+if TYPE_CHECKING:
+    from typing import Type, TypeVar
+
+    T = TypeVar("T", bound="ConfigSection")
+
+
+if "E3_CONFIG" in os.environ:
+    KNOWN_CONFIG_FILES = [os.environ["E3_CONFIG"]]
+else:
+    KNOWN_CONFIG_FILES = [
+        os.path.join(
+            os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")),
+            "e3.toml",
+        ),
+        os.path.expanduser("~/e3.toml"),
+    ]
+
+
+@dataclass
+class ConfigSection:
+    title: ClassVar[str]
+
+    @classmethod
+    def load(cls: Type[T]) -> T:
+        """Load a section of the configuration file.
+
+        To load a new section, subclass ConfigSection and document the
+        fields that you expect to parse, e.g.
+
+        @dataclass
+        class MyConfig(ConfigSection):
+            title = "my_config_subsection"
+            option : str = "default value"
+
+        my_config = MyConfig.load()
+
+        If the package typeguard is installed type defined in the metaclass
+        will be verified.
+        """
+        schema = get_type_hints(cls)
+        cls_fields = {f.name: schema[f.name] for f in fields(cls) if f.name != "title"}
+        kwargs = {}
+
+        for k, v in Config.load_section(cls.title).items():
+            if k in cls_fields:
+                ftype = cls_fields[k]
+                try:
+                    if CONFIG_CHECK_TYPE:
+                        check_type(f"{cls.title}.{k}", v, ftype)
+                except TypeError as err:
+                    logging.error(str(err))
+                else:
+                    kwargs[k] = v
+
+        return cls(**kwargs)  # type: ignore
+
+
+class Config:
+    """Load e3 configuration file and validate each section.
+
+    This class expose the .load_section(<section>, <dataclass>) method
+    that can be used by ConfigSection instance corresponding to the loaded
+    configuration section after validation.
+
+    Note that without the tomlkit package the configuration is not read.
+    """
+
+    data: ClassVar[dict] = {}
+
+    @classmethod
+    def load_section(cls, section: str) -> dict:
+        """Load a configuration section content.
+
+        :param section: if contains "." nested subsection will be found. For
+            instance "log.fmt" will return the section:
+
+            [log]
+              [log.fmt]
+        :return: the configuration dict
+        """
+
+        if not cls.data:
+            cls.load()
+
+        subsections = section.split(".")
+        result = cls.data
+        for subsection in subsections:
+            result = result.get(subsection, {})
+
+        return result
+
+    @classmethod
+    def load_file(cls, filename: str) -> None:
+        """Load the configuration file(s).
+
+        Note that this method is automatically loaded the first time .get()
+        is called.
+
+        :param filename: configuration file to load
+        """
+        try:
+            from tomlkit import parse
+            from tomlkit.exceptions import TOMLKitError
+        except ImportError:  # defensive code
+            logging.error(f"cannot load {filename} (cannot import tomlkit)")
+        else:
+            with open(filename) as f:
+                try:
+                    cls.data.update(parse(f.read()))
+                except TOMLKitError as e:
+                    logging.error(str(e))
+
+    @classmethod
+    def load(cls) -> None:
+        """Load the configuration file(s).
+
+        Note that this method is automatically loaded the first time .get()
+        is called.
+
+        :param filename: if not None load this configuration file instead of
+            the default config files
+        """
+        for config_file in KNOWN_CONFIG_FILES:
+            if os.path.isfile(config_file):
+                cls.load_file(config_file)

--- a/src/e3/log.py
+++ b/src/e3/log.py
@@ -1,24 +1,35 @@
 """Extensions to the standard Python logging system."""
 
 from __future__ import annotations
+from dataclasses import dataclass
 
 import logging
 import re
 import sys
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from colorama import Fore, Style
 
 from tqdm import tqdm
 
+from e3.config import ConfigSection
+
 if TYPE_CHECKING:
     from typing import Any, IO, Optional, Iterator, TextIO, Union
 
 
-# Define default format for StreamHandler and FileHandler
-DEFAULT_STREAM_FMT = "%(levelname)-8s %(message)s"
-DEFAULT_FILE_FMT = "%(asctime)s: %(name)-24s: %(levelname)-8s %(message)s"
+@dataclass
+class LogConfig(ConfigSection):
+    title: ClassVar[str] = "log"
+
+    pretty: bool = True
+    stream_fmt: str = "%(levelname)-8s %(message)s"
+    file_fmt: str = "%(asctime)s: %(name)-24s: %(levelname)-8s %(message)s"
+
+
+log_config = LogConfig.load()
+
 
 # Default output stream (sys.stdout by default, or a file descriptor if
 # activate() is called with a filename.
@@ -27,7 +38,7 @@ default_output_stream: Union[TextIO, IO[str]] = sys.stdout
 # If sys.stdout is a terminal then enable "pretty" output for user
 # This includes progress bars and colors
 if sys.stdout.isatty():  # all: no cover (not used in production!)
-    pretty_cli = True
+    pretty_cli = log_config.pretty
 else:
     pretty_cli = False
 
@@ -150,8 +161,8 @@ def add_log_handlers(
 
 
 def activate(
-    stream_format: str = DEFAULT_STREAM_FMT,
-    file_format: str = DEFAULT_FILE_FMT,
+    stream_format: str = log_config.stream_fmt,
+    file_format: str = log_config.file_fmt,
     datefmt: Optional[str] = None,
     level: int = logging.INFO,
     filename: Optional[str] = None,

--- a/src/e3/sys.py
+++ b/src/e3/sys.py
@@ -5,6 +5,8 @@ import os
 import re
 import sys
 from enum import Enum
+from dataclasses import asdict
+from pprint import pformat
 from typing import TYPE_CHECKING
 
 import e3.log
@@ -181,6 +183,9 @@ def main() -> None:
     m.argument_parser.add_argument(
         "--check", help="Run e3 sanity checking", action="store_true"
     )
+    m.argument_parser.add_argument(
+        "--show-config", action="store_true", help="Show e3 config"
+    )
     m.parse_args()
 
     if TYPE_CHECKING:
@@ -199,6 +204,11 @@ def main() -> None:
             return
     elif m.args.platform_info:
         print(getattr(Env(), m.args.platform_info))
+
+    if m.args.show_config:
+        print("[log]")
+        for k, v in asdict(e3.log.log_config).items():
+            print("{}: {}".format(k, pformat(v)))
 
 
 def set_python_env(prefix: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ def init_testsuite_env():
     # Force UTC timezone
     os.environ["TZ"] = "UTC"
     os.environ["E3_ENABLE_FEATURE"] = "smtp_ssl"
+    os.environ["E3_CONFIG"] = "/dev/null"
     # Ignore E3_HOSTNAME variable
     if "E3_HOSTNAME" in os.environ:
         del os.environ["E3_HOSTNAME"]

--- a/tests/tests_e3/config/main_test.py
+++ b/tests/tests_e3/config/main_test.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from e3.config import Config, ConfigSection
+
+
+def test_config():
+    with open("e3.toml", "w") as f:
+        f.write(
+            '[e3]\nfoo = 2\n  [e3.log]\n  pretty = false\n  stream_fmt = "%(message)s"'
+        )
+
+    Config.load_file("e3.toml")
+    print(Config.data)
+
+    @dataclass
+    class MyConfig(ConfigSection):
+        title = "e3.log"
+        pretty: bool = True
+
+    config = MyConfig.load()
+    print(config)
+    assert not config.pretty

--- a/tests/tests_e3/conftest.py
+++ b/tests/tests_e3/conftest.py
@@ -6,6 +6,7 @@ import yaml
 from e3.env import Env
 from e3.fs import rm
 from e3.os.fs import cd, which
+from e3.config import Config
 
 import pytest
 
@@ -41,6 +42,7 @@ def env_protect(request):
     Env().store()
     tempd = tempfile.mkdtemp()
     cd(tempd)
+    Config.data = {}
 
     def restore_env():
         Env().restore()

--- a/tests/tests_e3/main/main_test.py
+++ b/tests/tests_e3/main/main_test.py
@@ -1,3 +1,4 @@
+import os
 import re
 import sys
 
@@ -12,6 +13,28 @@ def test_main():
         e3.env.Env().build.platform
         in e3.os.process.Run(["e3", "--platform-info=build"]).out
     )
+
+
+def test_main_config():
+    os.environ["E3_CONFIG"] = "e3.toml"
+    assert "pretty: True" in e3.os.process.Run(["e3", "--show-config"]).out
+
+    with open("e3.toml", "w") as f:
+        f.write("[log]\npretty = false\n")
+    assert "pretty: False" in e3.os.process.Run(["e3", "--show-config"]).out
+
+    # Verify that invalid config field is ignored
+    with open("e3.toml", "w") as f:
+        f.write('[log]\npretty = "false"\nstream_fmt = "%(message)s"')
+    out = e3.os.process.Run(["e3", "--show-config"]).out
+    assert "pretty: True" in out
+    assert "stream_fmt: '%(message)s'" in out
+    assert "type of log.pretty must be bool" in out
+
+    # And finally check that invalid toml are discarded
+    with open("e3.toml", "w") as f:
+        f.write("this is an invalid toml content")
+    assert "pretty: True" in e3.os.process.Run(["e3", "--show-config"]).out
 
 
 def test_mainprog():

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
      codecov: codecov
 
 passenv = APPVEYOR* TRAVIS TRAVIS_* CI
+extras = config
 
 # Run testsuite with coverage when '-cov' is in the env name
 commands=


### PR DESCRIPTION
e3 config file is based on the toml format, to use it you need to
first choose a specific section, e.g. [log] for e3.log and define
a dataclass and will contain the configuration

@dataclass
class LogConfig(ConfigSection):
    title = "log"

    # Define default format for StreamHandler and FileHandler
    pretty: bool = True
    stream_fmt: str = "%(levelname)-8s %(message)s"
    file_fmt: str = "%(asctime)s: %(name)-24s: %(levelname)-8s %(message)s"

Then calling config_log = Config.get("log", LogConfig) will return the log
configuration.

If the log file is:

[log]
pretty = False

config_log.pretty will be set to True while config_log.stream_fmt and
config_log.file_fmt will keep their default values.