### PR TITLE
Add support to emit JSON log

### DIFF
--- a/src/e3/main.py
+++ b/src/e3/main.py
@@ -105,6 +105,13 @@ class Main:
             help="disable color and progress bars",
         )
         log_group.add_argument(
+            "--json-log",
+            default=False,
+            action="store_true",
+            help="enable JSON formatted logs",
+        )
+
+        log_group.add_argument(
             "--console-logs",
             metavar="LINE_PREFIX",
             help="disable color, progress bars, and redirect as much as"
@@ -191,7 +198,10 @@ class Main:
                 e3.log.console_logs = self.args.console_logs
 
             e3.log.activate(
-                level=level, filename=self.args.log_file, e3_debug=self.args.verbose > 1
+                level=level,
+                filename=self.args.log_file,
+                json_format=self.args.json_log,
+                e3_debug=self.args.verbose > 1,
             )
             self.__log_handlers_set = True
 

--- a/tests/tests_e3/log/main_test.py
+++ b/tests/tests_e3/log/main_test.py
@@ -1,6 +1,6 @@
 import datetime
 import sys
-
+import json
 import dateutil.parser
 import e3.log
 import e3.os.process
@@ -32,3 +32,57 @@ def test_log():
         assert (
             datetime.datetime.utcnow() - dateutil.parser.parse(log_datetime)
         ).seconds < 10
+
+
+def test_json_log():
+    p = e3.os.process.Run(
+        [
+            sys.executable,
+            "-c",
+            "\n".join(
+                (
+                    "import e3.log",
+                    'e3.log.activate(filename="log.json",json_format=True)',
+                    "e3.log.add_formatter_attr(['size'])",
+                    'l = e3.log.getLogger("test_log")',
+                    'l.debug("this is a log record")',
+                    "l.debug(\"extra key\",extra={'size':'100'})",
+                )
+            ),
+        ]
+    )
+
+    assert p.status == 0
+
+    with open("log.json") as f:
+        lines = f.readlines()
+
+    record = json.loads(lines[0])
+    # verify if we get default json fields
+    assert len(record.keys()) == 5
+
+    # verify presence of custom size field
+    record = json.loads(lines[1])
+    assert "size" in record
+
+
+def test_json_log_compat():
+    """we make sure that code do not crash if json is not activated."""
+    p = e3.os.process.Run(
+        [
+            sys.executable,
+            "-c",
+            "\n".join(
+                (
+                    "import e3.log",
+                    'e3.log.activate(filename="log.json")',
+                    "e3.log.add_formatter_attr(['size'])",
+                    'l = e3.log.getLogger("test_log")',
+                    'l.debug("this is a log record")',
+                    "l.debug(\"extra key\",extra={'size':'100'})",
+                )
+            ),
+        ]
+    )
+
+    assert p.status == 0


### PR DESCRIPTION
A new formatter was added which produces JSON logs. To activate it
the parameter --json-log is used.

Custom attributes can be added using the method add_formatter_attr
and they can be used using the keywork 'extra':

    logger.debug("message!!", extra={'size': '100'})