### PR TITLE
Ignore typing issue when calling copyfileobj

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,6 @@ repos:
     hooks:
     - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.770
+    rev: v0.780
     hooks:
     - id: mypy

--- a/src/e3/fs.py
+++ b/src/e3/fs.py
@@ -749,12 +749,12 @@ def sync_tree(
             try:
                 with open(src.path, "rb") as fsrc:
                     with open(dst.path, "wb") as fdst:
-                        shutil.copyfileobj(fsrc, fdst)
+                        shutil.copyfileobj(fsrc, fdst)  # type: ignore
             except OSError:
                 rm(dst.path, glob=False)
                 with open(src.path, "rb") as fsrc:
                     with open(dst.path, "wb") as fdst:
-                        shutil.copyfileobj(fsrc, fdst)
+                        shutil.copyfileobj(fsrc, fdst)  # type: ignore
             copystat(src, dst)
 
     def safe_mkdir(dst: FileInfo) -> None:


### PR DESCRIPTION
mypy 0.780 raise an error on the two calls to copyfileobj
Given that this is very local and that the code is known to work
well ignore the error which looks like a bug in typeshed

Also update mypy in pre-commit to match the version used by tox,
otherwise it reports that the type: ignore annotation are not needed.