### PR TITLE
Handle nicely cases in which output of the process is not in utf-8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,12 @@
     * e3.anod.context.AnodContext.add_spec ``env`` and ``primitive``
   * some attribute have been replaced by properties to avoid being marked as Optional
     * e3.anod.spec.Anod ``build_space``
+  * e3.os.process out and err attributes preserve CR characters
 * Deprecate e3.decorator.memoize, use functools.lru_cache instead
+* Prevent crash when a process launched by e3.os.process.Run does not emit utf-8
+  on stdout or stderr. Output and error is now processed using bytes_as_str and
+  bytes version of output and error is available through raw_out and raw_err
+  attributes.
 
 # Version 22.0.0 (2020-03-13)
 

--- a/tests/tests_e3/os/process/main_test.py
+++ b/tests/tests_e3/os/process/main_test.py
@@ -24,7 +24,7 @@ def test_run_shebang(caplog):
         f.write(b'print("running %s" % sys.argv[1])\n')
     e3.os.fs.chmod("a+x", prog_filename)
     p = e3.os.process.Run([prog_filename, "atest"], parse_shebang=True)
-    assert p.out == "running atest\n"
+    assert p.out.replace("\r", "") == "running atest\n"
 
     # Create a shebang spawning a file that does not exist
     with open(prog_filename, "wb") as f:

--- a/tests/tests_e3/os/process/main_test.py
+++ b/tests/tests_e3/os/process/main_test.py
@@ -38,6 +38,21 @@ def test_run_shebang(caplog):
     assert "doesnot exist" in caplog.text
 
 
+def test_split_err_out():
+    """Split err and out to distinct pipes."""
+    p = e3.os.process.Run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; sys.stdout.write('stdout'); sys.stderr.write('stderr')",
+        ],
+        output=e3.os.process.PIPE,
+        error=e3.os.process.PIPE,
+    )
+    assert p.out == "stdout"
+    assert p.err == "stderr"
+
+
 def test_rlimit():
     """rlimit kill the child process after a timeout."""
 

--- a/tests/tests_e3/os/process/main_test.py
+++ b/tests/tests_e3/os/process/main_test.py
@@ -53,6 +53,14 @@ def test_split_err_out():
     assert p.err == "stderr"
 
 
+def test_non_utf8_out():
+    """Test that we can get an output for a process not emitting utf-8."""
+    p = e3.os.process.Run(
+        [sys.executable, "-c", "import sys; sys.stdout.buffer.write(b'\\xff\\xff')"]
+    )
+    assert p.out == "\\xff\\xff"
+
+
 def test_rlimit():
     """rlimit kill the child process after a timeout."""
 


### PR DESCRIPTION
When using output=PIPE, self.out will contains either a decoded utf-8
string or a string representation of the bytes produced by the process.
This ensure e3.os.process does not crash in case the output is not in
utf-8. Do likewise for errror.