### PR TITLE
Avoid using os.path.expanduser

### DIFF
--- a/src/e3/anod/checkout.py
+++ b/src/e3/anod/checkout.py
@@ -99,9 +99,6 @@ class CheckoutManager:
         :param url: path to the repository
         :param revision: ignored
         """
-        # Expand env variables and ~
-        url = os.path.expandvars(os.path.expanduser(url))
-
         if os.path.isdir(self.working_dir):
             old_commit = get_filetree_state(self.working_dir)
         else:

--- a/src/e3/anod/sandbox/__init__.py
+++ b/src/e3/anod/sandbox/__init__.py
@@ -133,8 +133,7 @@ class SandBox:
 
         :param d: directory where to find anod specification files
         """
-        # Expand ~, environment variables and eliminate symbolic links
-        self.__specs_dir = os.path.realpath(os.path.expandvars(os.path.expanduser(d)))
+        self.__specs_dir = d
         self.is_alternate_specs_dir = True
         logger.debug("using alternate specs dir %s", d)
 


### PR DESCRIPTION
os.path.expanduser behaviour has recently changed on windows and it might be confusing for cygwin users. When possible avoid relying on it.