### PR TITLE
Use url safe version base64 decoding.

### DIFF
--- a/src/e3/net/token.py
+++ b/src/e3/net/token.py
@@ -21,7 +21,7 @@ def get_payload(token: str) -> dict:
         if rem > 0:
             payload += "=" * (4 - rem)
         try:
-            data = json.loads(base64.b64decode(payload).decode("utf-8"))
+            data = json.loads(base64.urlsafe_b64decode(payload).decode("utf-8"))
         except (ValueError, TypeError):
             pass
     return data


### PR DESCRIPTION
Necessary in order to be able to decode tokens emited by AWS Cognito