### PR TITLE
Get rid of unused is_virtual discriminant

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Version 22.2.0 (2020-??-??) *NOT RELEASED YET*
 
+* Minor backward incompatible changes:
+  * the discrimiant ``is_virtual`` has been removed
+
 # Version 22.1.0 (2020-06-22)
 
 * Add type hinting and verify it with ``mypy``

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -98,7 +98,6 @@ Add ``print(Env().build`` will output more info on the build platform:
     machine:  ida
     is_hie:   False
     is_host:  True
-    is_virtual: False
     triplet:  x86_64-apple-darwin16.5.0
     domain:   unknown
     OS

--- a/mypy.ini
+++ b/mypy.ini
@@ -23,9 +23,6 @@ ignore_missing_imports = True
 [mypy-ld.*]
 ignore_missing_imports = True
 
-[mypy-netifaces.*]
-ignore_missing_imports = True
-
 [mypy-psutil.*]
 ignore_missing_imports = True
 

--- a/src/e3/env.py
+++ b/src/e3/env.py
@@ -467,9 +467,6 @@ class AbstractBaseEnv(metaclass=abc.ABCMeta):
         if self.target.os.name.lower() == "windows":
             discs.append("NT")
 
-        if (not self.is_cross and not self.is_canadian) and self.build.is_virtual:
-            discs.append("virtual_machine")  # all: no cover
-
         return discs
 
     @property

--- a/src/e3/platform.py
+++ b/src/e3/platform.py
@@ -131,23 +131,12 @@ class Platform(
             is_default,
         )
 
-    @property
-    def is_virtual(self) -> bool:
-        """Check if we are on a virtual system.
-
-        :return: True if the system represented by Arch is a virtual machine
-        """
-        if not self.is_host:
-            return False
-        return self.system_info.is_virtual()
-
     def to_dict(self) -> Dict[str, Any]:
         """Export os and cpu variables as os_{var} and cpu_{var}.
 
         :return: a dictionary representing the current Arch instance
         """
         str_dict = self._asdict()
-        str_dict["is_virtual"] = self.is_virtual
 
         for key, var in self.os.as_dict().items():
             str_dict["os_" + key] = var
@@ -164,7 +153,6 @@ class Platform(
             "machine:  %(machine)s\n"
             "is_hie:   %(is_hie)s\n"
             "is_host:  %(is_host)s\n"
-            "is_virtual: %(is_virtual)s\n"
             "triplet:  %(triplet)s\n"
             "domain:   %(domain)s\n"
             "OS\n"

--- a/tests/tests_e3/os/platform/main_test.py
+++ b/tests/tests_e3/os/platform/main_test.py
@@ -16,22 +16,6 @@ def test_system_info():
     assert s.os_version() == os_version
 
 
-def test_is_virtual():
-    """Check detection of virtual machines."""
-    s = e3.os.platform.SystemInfo
-    is_virtual = s.is_virtual()
-    s.reset_cache()
-    assert s.is_virtual() == is_virtual
-
-    # Second call should use the cache
-    assert s.is_virtual() == is_virtual
-
-    # Detect virtual machine (fake the network here)
-    s.network_ifs = {"eth0": {"AF_LINK": [{"addr": "00:0c:29:dc:40:00"}]}}
-    s._is_virtual = None
-    assert s.is_virtual() is True
-
-
 def test_hostname():
     """Test SystemInfo.hostname."""
     s = e3.os.platform.SystemInfo


### PR DESCRIPTION
The mechanism used to detect whether a machine was virtual or not was
not reliable enough.

TN: T421-011