### PR TITLE
Reject untyped function definitions

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -6,6 +6,7 @@ warn_unused_configs = True
 disallow_untyped_calls = True
 warn_unreachable = True
 disallow_incomplete_defs = True
+disallow_any_unimported = True
 no_implicit_optional = True
 
 # Currently disabled (from easiest to hardest)

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,13 +4,36 @@ warn_redundant_casts = True
 warn_unused_ignores = True
 warn_unused_configs = True
 disallow_untyped_calls = True
+disallow_untyped_defs = True
 warn_unreachable = True
 disallow_incomplete_defs = True
 disallow_any_unimported = True
+disallow_subclassing_any = True
 no_implicit_optional = True
 
-# Currently disabled (from easiest to hardest)
-# disallow_untyped_defs = True
+[mypy-tests.tests_e3.*]
+disallow_untyped_defs = False
+
+# Less strict rules for modules that are not considered part of the core system
+[mypy-e3.anod.sandbox.action.*]
+disallow_untyped_defs = False
+
+[mypy-e3.anod.sandbox.migrate.*]
+disallow_untyped_defs = False
+
+[mypy-e3.anod.sandbox.scripts.*]
+disallow_untyped_defs = False
+
+[mypy-e3.anod.driver.*]
+disallow_untyped_defs = False
+
+# Covering windows specific API is too difficult and not worth it
+[mypy-e3.os.windows.native_api.*]
+disallow_untyped_defs = False
+
+# Covering code on top of pyyaml is too difficult and not worth it
+[mypy-e3.yaml.*]
+disallow_untyped_defs = False
 
 [mypy-colorama.*]
 ignore_missing_imports = True

--- a/src/e3/anod/context.py
+++ b/src/e3/anod/context.py
@@ -789,7 +789,7 @@ class AnodContext:
             return cls.decision_error(action, decision)
 
     @classmethod
-    def always_create_source_resolver(cls, action, decision):
+    def always_create_source_resolver(cls, action: Action, decision: Decision) -> bool:
         """Force source creation when scheduling a plan."""
         if isinstance(action, CreateSource):
             return True

--- a/src/e3/anod/package.py
+++ b/src/e3/anod/package.py
@@ -11,7 +11,17 @@ from e3.fs import VCS_IGNORE_LIST, mkdir, rm, sync_tree
 
 
 if TYPE_CHECKING:
-    from typing import Callable, Dict, Final, List, Literal, NoReturn, Optional, Union
+    from typing import (
+        Any,
+        Callable,
+        Dict,
+        Final,
+        List,
+        Literal,
+        NoReturn,
+        Optional,
+        Union,
+    )
     from e3.anod.spec import Anod
 
     PrepareSrcCB = Callable[[Dict[str, Dict[str, str]], str], None]
@@ -213,9 +223,9 @@ class SourceBuilder:
         self.__prepare_src = prepare_src
         self.__apply_patch = apply_patch
 
-    def fullname(self, *args, **kwargs):
+    def fullname(self, *args: Any, **kwargs: Any) -> str:
         # ??? add support for the GPL mode
-        return self.__fullname(*args, **kwargs)
+        return self.__fullname(*args, **kwargs)  # type: ignore
 
     @property
     def prepare_src(self) -> Optional[PrepareSrcCB]:

--- a/src/e3/anod/sandbox/__init__.py
+++ b/src/e3/anod/sandbox/__init__.py
@@ -179,12 +179,12 @@ class SandBox:
         e3_distrib = get_distribution("e3-core")
 
         class SandboxDist:
-            def get_entry_map(self, group):
+            def get_entry_map(self, group):  # type: ignore
                 if group != "console_scripts":
                     return {}
                 return e3_distrib.get_entry_map("sandbox_scripts")
 
-            def as_requirement(self):
+            def as_requirement(self):  # type: ignore
                 return e3_distrib.as_requirement()
 
         for script in get_script_args(dist=SandboxDist()):

--- a/src/e3/anod/spec.py
+++ b/src/e3/anod/spec.py
@@ -318,8 +318,8 @@ class Anod:
         :raise: AnodError
         """
 
-        def primitive_dec(f, pre=pre, post=post, version=version):
-            def primitive_func(self, *args, **kwargs):
+        def primitive_dec(f, pre=pre, post=post, version=version):  # type: ignore
+            def primitive_func(self, *args, **kwargs):  # type: ignore
                 self.log.debug("%s %s starts", self.name, f.__name__)
 
                 result = False

--- a/src/e3/archive.py
+++ b/src/e3/archive.py
@@ -28,7 +28,7 @@ logger = e3.log.getLogger("archive")
 class E3ZipFile(zipfile.ZipFile):
     """Override default ZipFile with attributes preservation."""
 
-    def _extract_member(self, member, path, pwd):
+    def _extract_member(self, member, path, pwd):  # type: ignore
         result = super()._extract_member(member, path, pwd)
 
         if sys.platform != "win32":

--- a/src/e3/collection/toggleable_bool.py
+++ b/src/e3/collection/toggleable_bool.py
@@ -40,7 +40,7 @@ class ToggleableBooleanGroup:
     def __getitem__(self, key: int) -> ToggleableBoolean:
         return self.series[key]
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.series)
 
     def shuffle(self) -> Iterator[List[ToggleableBoolean]]:
@@ -87,5 +87,5 @@ class ToggleableBoolean:
     def __bool__(self) -> bool:
         return self.value
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.name}: {self.value}"

--- a/src/e3/decorator.py
+++ b/src/e3/decorator.py
@@ -46,7 +46,7 @@ def disabled(func: Callable) -> Callable:
     """
     del func
 
-    def empty_func(*args, **kargs):
+    def empty_func(*args: Any, **kargs: Any) -> None:
         del args, kargs
 
     return empty_func
@@ -115,7 +115,7 @@ class memoize:
         """Return the function's docstring."""
         return self.func.__doc__ or ""
 
-    def __get__(self, obj, objtype):
+    def __get__(self, obj: Any, objtype: Any) -> Any:
         """Support instance methods."""
         del objtype
         return partial(self.__call__, obj)

--- a/src/e3/electrolyt/entry_point.py
+++ b/src/e3/electrolyt/entry_point.py
@@ -107,7 +107,9 @@ def entry_point(
     :param kwargs: additional information to store with the entry point
     """
 
-    def entry_point_dec(f, ldb=db, lcls=cls, lkind=kind, largs=args, lkwargs=kwargs):
+    def entry_point_dec(  # type: ignore
+        f, ldb=db, lcls=cls, lkind=kind, largs=args, lkwargs=kwargs
+    ):
         lcls(ldb, f, lkind, *largs, **lkwargs)
         return f
 

--- a/src/e3/electrolyt/plan.py
+++ b/src/e3/electrolyt/plan.py
@@ -13,7 +13,8 @@ from e3.env import BaseEnv
 from e3.error import E3Error
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, List, Optional
+    from types import TracebackType
+    from typing import Any, Callable, Dict, List, Type, Optional
     from e3.collection.toggleable_bool import ToggleableBoolean
     from e3.electrolyt.entry_point import EntryPoint
 
@@ -345,11 +346,18 @@ class PlanContext:
         # Push the action in the current list
         self.action_list.append(result)
 
-    def __enter__(self):
+    def __enter__(self) -> None:
+        assert self.plan is not None
         self.plan.mod.__dict__["env"] = self.env
         return None
 
-    def __exit__(self, _type, _value, _tb):
+    def __exit__(
+        self,
+        _type: Optional[Type[BaseException]],
+        _value: Optional[BaseException],
+        _tb: Optional[TracebackType],
+    ) -> None:
         del _type, _value, _tb
         self.stack.pop()
+        assert self.plan is not None
         self.plan.mod.__dict__["env"] = self.env

--- a/src/e3/event/__init__.py
+++ b/src/e3/event/__init__.py
@@ -19,7 +19,8 @@ from e3.fs import mkdir
 logger = e3.log.getLogger("event")
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, Optional, Tuple, Union
+    from types import TracebackType
+    from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
 
 
 def unique_id() -> str:
@@ -77,7 +78,12 @@ class Event:
     def __enter__(self) -> Event:
         return self
 
-    def __exit__(self, _type, _value, _tb):
+    def __exit__(
+        self,
+        _type: Optional[Type[BaseException]],
+        _val: Optional[BaseException],
+        _tb: Optional[TracebackType],
+    ) -> None:
         self.close()
 
     def set_formatter(self, key: str, fun: Callable[[str, Any], dict]) -> None:

--- a/src/e3/event/handler/file.py
+++ b/src/e3/event/handler/file.py
@@ -1,17 +1,23 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import json
 import os
 
 from e3.event import EventHandler
 from e3.fs import cp, mkdir
 
+if TYPE_CHECKING:
+    from typing import Dict
+    from e3.event import Event
+
 
 class FileHandler(EventHandler):
-    def __init__(self, log_dir):
+    def __init__(self, log_dir: str) -> None:
         self.log_dir = log_dir
 
-    def send_event(self, event):
+    def send_event(self, event: Event) -> bool:
         d = event.as_dict()
         prefix = "{}-{}".format(d["name"], d["uid"])
         log_file = os.path.join(self.log_dir, prefix + ".log")
@@ -24,8 +30,8 @@ class FileHandler(EventHandler):
         return True
 
     @classmethod
-    def decode_config(cls, config_str):
+    def decode_config(cls, config_str: str) -> Dict[str, str]:
         return {"log_dir": config_str}
 
-    def encode_config(self):
+    def encode_config(self) -> str:
         return self.log_dir

--- a/src/e3/event/handler/logging.py
+++ b/src/e3/event/handler/logging.py
@@ -1,26 +1,33 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import json
 import logging
 
 import e3.log
 from e3.event import EventHandler
 
+if TYPE_CHECKING:
+    from typing import Dict, Union
+    from e3.event import Event
+
 
 class LoggingHandler(EventHandler):
-    def __init__(self, logger_name="", level=logging.DEBUG):
+    def __init__(self, logger_name: str = "", level: int = logging.DEBUG) -> None:
         self.logger_name = logger_name
         self.level = level
         self.log = e3.log.getLogger(logger_name)
 
-    def send_event(self, event):
+    def send_event(self, event: Event) -> bool:
         d = event.as_dict()
         self.log.log(self.level, json.dumps(d, indent=2))
+        return True
 
-    def decode_config(self, config_str):
+    @classmethod
+    def decode_config(cls, config_str: str) -> Dict[str, Union[str, int]]:
         logger_name, level = config_str.split(",")
-        level = int(level)
-        return {"logger_name": logger_name, "level": level}
+        return {"logger_name": logger_name, "level": int(level)}
 
-    def encode_config(self):
+    def encode_config(self) -> str:
         return f"{self.logger_name},{self.level}"

--- a/src/e3/log.py
+++ b/src/e3/log.py
@@ -26,10 +26,13 @@ if TYPE_CHECKING:
         TextIO,
         Union,
         List,
+        TypeVar,
         Tuple,
         Mapping,
     )
     from logging import _ExcInfoType
+
+    T = TypeVar("T")
 
 
 @dataclass
@@ -184,7 +187,7 @@ class E3LoggerAdapter(logging.LoggerAdapter):
         )
 
 
-def progress_bar(it: Union[Iterator, Sequence], **kwargs: Any) -> tqdm:
+def progress_bar(it: Union[Iterator[T], Sequence[T]], **kwargs: Any) -> Iterator[T]:
     """Create a tqdm progress bar.
 
     :param it: an interator

--- a/src/e3/log.py
+++ b/src/e3/log.py
@@ -11,7 +11,6 @@ import json
 from typing import TYPE_CHECKING, ClassVar
 
 from colorama import Fore, Style
-
 from tqdm import tqdm
 
 from e3.config import ConfigSection

--- a/src/e3/main.py
+++ b/src/e3/main.py
@@ -40,7 +40,8 @@ import e3.log
 from e3.env import Env
 
 if TYPE_CHECKING:
-    from typing import Optional, List
+    from types import FrameType
+    from typing import Optional, List, NoReturn
     from argparse import Namespace
 
 
@@ -162,7 +163,7 @@ class Main:
         self.argument_parser = argument_parser
         self.__log_handlers_set = False
 
-        def sigterm_handler(sig, frame):  # unix-only
+        def sigterm_handler(sig: int, frame: FrameType) -> NoReturn:  # unix-only
             """Automatically convert SIGTERM to SystemExit exception.
 
             This is done to give enough time to an application killed by

--- a/src/e3/net/http.py
+++ b/src/e3/net/http.py
@@ -22,7 +22,8 @@ from e3.error import E3Error
 from e3.fs import rm
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Deque, Dict, List, Optional, Tuple, Union
+    from types import TracebackType
+    from typing import Any, Callable, Deque, Dict, List, Optional, Tuple, Type, Union
     from requests.auth import AuthBase
     from requests.models import Response
 
@@ -93,7 +94,12 @@ class HTTPSession:
         self.session.__enter__()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         self.session.__exit__(exc_type, exc_val, exc_tb)
 
     def set_max_retries(

--- a/src/e3/os/fs.py
+++ b/src/e3/os/fs.py
@@ -14,14 +14,14 @@ import re
 import shutil
 import stat
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 import e3
 import e3.error
 import e3.log
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, List, Optional, Tuple, Union
+    from typing import Any, Callable, List, Literal, Optional, Tuple, Union
 
 
 class OSFSError(e3.error.E3Error):
@@ -134,6 +134,16 @@ def chmod(mode: str, filename: str) -> int:
 
     os.chmod(filename, current_mode)
     return current_mode
+
+
+@overload
+def df(path: str) -> int:
+    ...
+
+
+@overload
+def df(path: str, full: Literal[True]) -> Tuple:
+    ...
 
 
 def df(path: str, full: bool = False) -> Union[int, Tuple]:

--- a/src/e3/os/platform.py
+++ b/src/e3/os/platform.py
@@ -13,7 +13,7 @@ from e3.platform_db import get_knowledge_base
 
 
 if TYPE_CHECKING:
-    from typing import Optional, Tuple, Union
+    from typing import Any, Dict, Optional, Tuple, Union
 
 KNOWLEDGE_BASE = get_knowledge_base()
 
@@ -379,7 +379,7 @@ class CPU(namedtuple("CPU", ["name", "bits", "endian", "cores"])):
 
     __slots__ = ()
 
-    def as_dict(self):
+    def as_dict(self) -> Dict[str, Any]:
         return self._asdict()
 
     @classmethod
@@ -432,7 +432,7 @@ class OS(
 
     __slots__ = ()
 
-    def as_dict(self):
+    def as_dict(self) -> Dict[str, Any]:
         return self._asdict()
 
     @classmethod

--- a/src/e3/os/process.py
+++ b/src/e3/os/process.py
@@ -405,12 +405,14 @@ class Run:
                 self.internal = Popen(self.cmds[0], **popen_args)
 
             else:
-                runs: List[Popen] = []
+                runs: List[subprocess.Popen] = []
                 for index, cmd in enumerate(self.cmds):
                     if index == 0:
-                        stdin = self.input_file.fd
+                        stdin: Union[int, IO[Any]] = self.input_file.fd
                     else:
-                        stdin = runs[index - 1].stdout
+                        previous_stdout = runs[index - 1].stdout
+                        assert previous_stdout is not None
+                        stdin = previous_stdout
 
                     # When connecting two processes using a Pipe don't use
                     # universal_newlines mode. Indeed commands transmitting

--- a/src/e3/os/process.py
+++ b/src/e3/os/process.py
@@ -601,7 +601,7 @@ class Run:
         else:
             return self.internal.is_running()
 
-    def children(self) -> List[psutil.Process]:
+    def children(self) -> List[Any]:
         """Return list of child processes (using psutil)."""
         if psutil is None:  # defensive code
             raise NotImplementedError("Run.children() require psutil")
@@ -784,7 +784,7 @@ def is_running(pid: int) -> bool:
         return True
 
 
-def kill_process_tree(pid: Union[int, psutil.Process], timeout: int = 3) -> bool:
+def kill_process_tree(pid: Union[int, Any], timeout: int = 3) -> bool:
     """Kill a hierarchy of processes.
 
     :param pid: pid of the toplevel process

--- a/src/e3/os/windows/native_api.py
+++ b/src/e3/os/windows/native_api.py
@@ -50,7 +50,7 @@ class FileAttribute(Structure):
 
     _fields_ = [("attr", ULONG)]
 
-    def __str__(self):
+    def __str__(self) -> str:
         result = []
         for k in FileAttribute.__dict__:
             if not k.startswith("_") and k.isupper():
@@ -166,20 +166,20 @@ class FileTime(Structure):
 
     _fields_ = [("filetime", LARGE_INTEGER)]
 
-    def __init__(self, t):
+    def __init__(self, t: datetime) -> None:
         timestamp = (t - datetime(1970, 1, 1)).total_seconds()
         timestamp = (int(timestamp) + 11644473600) * 10000000
         Structure.__init__(self, timestamp)
 
     @property
-    def as_datetime(self):
+    def as_datetime(self) -> datetime:
         try:
             return datetime.fromtimestamp(self.filetime // 10000000 - 11644473600)
         except ValueError as err:  # defensive code
             # Add some information to ease debugging
             raise ValueError(f"filetime '{self.filetime}' failed with {err}")
 
-    def __str__(self):
+    def __str__(self) -> str:
         try:
             return str(time.ctime(self.filetime // 10000000 - 11644473600))
         except ValueError:  # defensive code

--- a/src/e3/platform.py
+++ b/src/e3/platform.py
@@ -109,6 +109,7 @@ class Platform(
             is_default = platform_name == default_platform
 
         # Fill other attributes
+        assert platform_name is not None
         pi = KNOWLEDGE_BASE.platform_info[platform_name]
         cpu = e3.os.platform.CPU.get(pi["cpu"], pi.get("endian", None), is_host)
         os = e3.os.platform.OS.get(pi["os"], is_host, version=version, mode=mode)

--- a/src/e3/platform_db/knowledge_base.py
+++ b/src/e3/platform_db/knowledge_base.py
@@ -5,8 +5,12 @@ knowledge base is very often read and the cost of parsing the data can
 be significant in some context.
 """
 from __future__ import annotations
+from typing import TYPE_CHECKING
 
-CPU_INFO = {
+if TYPE_CHECKING:
+    from e3.platform_db import PlatformDBEntry
+
+CPU_INFO: PlatformDBEntry = {
     "aarch64": {"endian": "little", "bits": 64},
     "arm": {"endian": "little", "bits": 32},
     "avr": {"endian": "little", "bits": 16},
@@ -18,7 +22,7 @@ CPU_INFO = {
     "x86_64": {"endian": "little", "bits": 64},
 }
 
-OS_INFO = {
+OS_INFO: PlatformDBEntry = {
     "aix": {"is_bareboard": False, "version": "5.2", "exeext": "", "dllext": ".so"},
     "darwin": {
         "is_bareboard": False,
@@ -72,7 +76,7 @@ OS_INFO = {
     "none": {"is_bareboard": True, "version": "unknown", "exeext": "", "dllext": ""},
 }
 
-PLATFORM_INFO = {
+PLATFORM_INFO: PlatformDBEntry = {
     "aarch64-elf": {"cpu": "aarch64", "os": "none", "is_hie": True},
     "aarch64-ios": {"cpu": "aarch64", "os": "ios", "is_hie": False},
     "aarch64-linux": {"cpu": "aarch64", "os": "linux", "is_hie": False},
@@ -109,7 +113,7 @@ PLATFORM_INFO = {
     "x86_64-windows64": {"cpu": "x86_64", "os": "windows", "is_hie": False},
 }
 
-BUILD_TARGETS = {
+BUILD_TARGETS: PlatformDBEntry = {
     "aarch64-elf": {"name": "aarch64-elf"},
     "aarch64-ios": {"name": "aarch64-apple-darwin"},
     "aarch64-linux": {"name": "aarch64-linux-gnu"},
@@ -150,7 +154,7 @@ BUILD_TARGETS = {
 # by a different host. IMPORTANT: Systems that can be only used as target in
 # cross context should not be added to that table.
 
-HOST_GUESS = {
+HOST_GUESS: PlatformDBEntry = {
     # platform : OS (uname[0]), machine (uname[1]), proc (uname[4 or 5])
     "ppc-aix": {"os": "AIX", "cpu": None},
     "x86_64-darwin": {"os": "Darwin", "cpu": "i386"},

--- a/src/e3/store/__init__.py
+++ b/src/e3/store/__init__.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import stevedore
 
+if TYPE_CHECKING:
+    from typing import Any
+    from e3.store.cache.backends.base import Cache
+    from e3.store.backends.base import Store
 
-def load_store(name, configuration, cache):
+
+def load_store(name: str, configuration: Any, cache: Cache) -> Store:
     plugin = stevedore.DriverManager("e3.store", name)
 
     return plugin.driver(configuration, cache)

--- a/src/e3/store/cache/__init__.py
+++ b/src/e3/store/cache/__init__.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 
 import stevedore
 
+if TYPE_CHECKING:
+    from typing import Any
+    from e3.store.cache.backends.base import Cache
 
-def load_cache(name="file-cache", configuration=None):
+
+def load_cache(name: str = "file-cache", configuration: Any = None) -> Cache:
     plugin = stevedore.DriverManager(namespace="e3.store.cache.backend", name=name)
     return plugin.driver(configuration)


### PR DESCRIPTION
Add disallow_untyped_defs = True to mypy configuration
and disable it when:

- the cost of adding the type hinting is too high (e.g. windows low-level specific code), or
- the modules are not used in production and meant to be replaced in the future