### PR TITLE
Modify fingerprint handling of files and directories:

### DIFF
--- a/src/e3/fingerprint.py
+++ b/src/e3/fingerprint.py
@@ -78,8 +78,10 @@ class Fingerprint:
 
         :param path: a path to a directory
         """
-        assert os.path.isdir(path), "directory %s does not exist" % path
-        self.elements[os.path.basename(path)] = get_filetree_state(path)
+        if os.path.isdir(path):
+            self.elements[os.path.abspath(path)] = get_filetree_state(path)
+        else:
+            self.elements[os.path.abspath(path)] = ""
 
     def add_file(self, filename: str) -> None:
         """Add a file element to the fingerprint.
@@ -90,8 +92,10 @@ class Fingerprint:
         an element for which key is the basename of the file and value is
         is the sha256 of the content
         """
-        assert os.path.isfile(filename), "filename %s does not exist" % filename
-        self.elements[os.path.basename(filename)] = sha256(filename)
+        if os.path.isfile(filename):
+            self.elements[os.path.abspath(filename)] = sha256(filename)
+        else:
+            self.elements[os.path.abspath(filename)] = ""
 
     def __eq__(self, other: object) -> bool:
         """Implement == operator for two fingerprints.

--- a/tests/tests_e3/fingerprint_test.py
+++ b/tests/tests_e3/fingerprint_test.py
@@ -26,7 +26,7 @@ def test_fingerprint():
     f23_diff = f3.compare_to(f2)
     assert f23_diff["new"] == {"foo"}
     assert f23_diff["updated"] == set()
-    assert f23_diff["obsolete"] == {os.path.basename(__file__)}
+    assert f23_diff["obsolete"] == {os.path.abspath(__file__)}
 
     assert f1.checksum() != f2.checksum() != f3.checksum()
 


### PR DESCRIPTION
* If the directory or the file does not exist don't crash. Just
  associate an empty string
* Use full path as key rather than basename to avoid key collisions

Part of T701-031