### PR TITLE
Force having a root_dir when instantiating a SandBox

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Minor backward incompatible changes:
   * the discrimiant ``is_virtual`` has been removed
+  * e3.anod.sandbox.SandBox now has a mandatory root_dir attribute
 
 # Version 22.1.0 (2020-06-22)
 

--- a/src/e3/anod/sandbox/__init__.py
+++ b/src/e3/anod/sandbox/__init__.py
@@ -136,7 +136,6 @@ class SandBox:
     def dump_configuration(self) -> None:
         # Compute command line for call to e3-sandbox create. Ensure that the
         # paths are made absolute (path to sandbox, script).
-        assert self.meta_dir is not None
         cmd_line = [sys.executable, os.path.abspath(__file__)]
         cmd_line += sys.argv[1:]
         sandbox_conf = os.path.join(self.meta_dir, "sandbox.yaml")
@@ -144,15 +143,12 @@ class SandBox:
             yaml.safe_dump({"cmd_line": cmd_line}, f)
 
     def get_configuration(self) -> dict:
-        assert self.meta_dir is not None
         sandbox_conf = os.path.join(self.meta_dir, "sandbox.yaml")
         with open(sandbox_conf) as f:
             return yaml.safe_load(f)
 
     def write_scripts(self) -> None:
         from setuptools.command.easy_install import get_script_args
-
-        assert self.bin_dir is not None
 
         # Retrieve sandbox_scripts entry points
         e3_distrib = get_distribution("e3-core")

--- a/src/e3/anod/sandbox/action.py
+++ b/src/e3/anod/sandbox/action.py
@@ -6,8 +6,9 @@ from typing import TYPE_CHECKING
 
 import e3.log
 from e3.anod.context import AnodContext
+from e3.anod.error import SandBoxError
 from e3.anod.loader import AnodSpecRepository
-from e3.anod.sandbox import SandBox, SandBoxError
+from e3.anod.sandbox import SandBox
 from e3.anod.sandbox.main import main
 from e3.anod.spec import check_api_version
 from e3.electrolyt.plan import Plan, PlanContext
@@ -79,8 +80,7 @@ class SandBoxCreate(SandBoxAction):
         )
 
     def run(self, args):
-        sandbox = SandBox()
-        sandbox.root_dir = args.sandbox
+        sandbox = SandBox(root_dir=args.sandbox)
 
         sandbox.create_dirs()
 
@@ -114,8 +114,7 @@ class SandBoxShowConfiguration(SandBoxAction):
             )
             print(msg)
 
-        sandbox = SandBox()
-        sandbox.root_dir = args.sandbox
+        sandbox = SandBox(root_dir=args.sandbox)
 
         try:
             cmd_line = sandbox.get_configuration()["cmd_line"]
@@ -160,8 +159,7 @@ class SandBoxExec(SandBoxCreate):
         self.parser.add_argument("--resolver", help="Use specific resolver")
 
     def run(self, args):
-        sandbox = SandBox()
-        sandbox.root_dir = args.sandbox
+        sandbox = SandBox(root_dir=args.sandbox)
 
         if args.specs_dir:
             sandbox.specs_dir = args.specs_dir

--- a/src/e3/anod/sandbox/migrate.py
+++ b/src/e3/anod/sandbox/migrate.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from e3.anod.sandbox import SandBoxError
+from e3.anod.error import SandBoxError
 from e3.anod.sandbox.action import SandBoxAction
 from e3.os.fs import cd
 

--- a/src/e3/anod/sandbox/scripts.py
+++ b/src/e3/anod/sandbox/scripts.py
@@ -30,8 +30,7 @@ def anod():
         os.path.join(os.path.dirname(sys.modules["__main__"].__file__), os.pardir)
     )
 
-    sandbox = e3.anod.sandbox.SandBox()
-    sandbox.root_dir = sandbox_dir
+    sandbox = e3.anod.sandbox.SandBox(root_dir=sandbox_dir)
 
     # Load the local specs
     spec_repo = e3.anod.loader.AnodSpecRepository(sandbox.specs_dir)

--- a/src/e3/electrolyt/run.py
+++ b/src/e3/electrolyt/run.py
@@ -116,7 +116,6 @@ class ElectrolytJob(Job):
             logger.error("%s vcs type not supported", repo_vcs)
             self.__status = STATUS.failure
             return
-        assert self.sandbox.vcs_dir is not None
         repo_dir = os.path.join(self.sandbox.vcs_dir, repo_name)
         g = GitRepository(repo_dir)
         if e3.log.default_output_stream is not None:
@@ -128,8 +127,6 @@ class ElectrolytJob(Job):
     def do_createsource(self) -> None:
         """Prepare src from vcs to cache using sourcebuilders."""
         source_name = self.data.source_name
-        assert self.sandbox.tmp_dir is not None
-        assert self.sandbox.vcs_dir is not None
         tmp_cache_dir = os.path.join(self.sandbox.tmp_dir, "cache")
         src = self.sandbox.vcs_dir
         src_builder = get_source_builder(
@@ -159,7 +156,6 @@ class ElectrolytJob(Job):
 
     def do_installsource(self) -> None:
         """Install the source from tmp/cache to build_space/src."""
-        assert self.sandbox.tmp_dir is not None
         spec = self.data.spec
         spec.sandbox = self.sandbox
         anod_instance = AnodDriver(anod_instance=spec, store=self.store)

--- a/tests/tests_e3/anod/helper_test.py
+++ b/tests/tests_e3/anod/helper_test.py
@@ -29,8 +29,7 @@ def test_make():
                 m2.cmdline("all")["cmd"],
             )
 
-    Anod.sandbox = SandBox()
-    Anod.sandbox.root_dir = os.getcwd()
+    Anod.sandbox = SandBox(root_dir=os.getcwd())
     Anod.sandbox.create_dirs()
 
     am = AnodMake(qualifier="", kind="build", jobs=10)
@@ -53,8 +52,7 @@ def test_configure():
             c = Configure(self)
             return c.cmdline()
 
-    Anod.sandbox = SandBox()
-    Anod.sandbox.root_dir = os.getcwd()
+    Anod.sandbox = SandBox(root_dir=os.getcwd())
     Anod.sandbox.create_dirs()
 
     ac = AnodConf(qualifier="", kind="build", jobs=10)
@@ -114,8 +112,7 @@ def test_configure_opts():
 
     os.environ["CONFIG_SHELL"] = "ksh"
 
-    Anod.sandbox = SandBox()
-    Anod.sandbox.root_dir = os.getcwd()
+    Anod.sandbox = SandBox(root_dir=os.getcwd())
     Anod.sandbox.create_dirs()
 
     ac = AnodConf(qualifier="", kind="build", jobs=10)

--- a/tests/tests_e3/anod/spec_test.py
+++ b/tests/tests_e3/anod/spec_test.py
@@ -94,8 +94,7 @@ def test_primitive():
     with_primitive3 = WithPrimitive("error2", "build")
     with_primitive4 = WithPrimitive("error3", "build")
 
-    Anod.sandbox = SandBox()
-    Anod.sandbox.root_dir = os.getcwd()
+    Anod.sandbox = SandBox(root_dir=os.getcwd())
     Anod.sandbox.spec_dir = os.path.join(os.path.dirname(__file__), "data")
     Anod.sandbox.create_dirs()
     # Activate the logging

--- a/tests/tests_e3/anod/test_driver.py
+++ b/tests/tests_e3/anod/test_driver.py
@@ -8,21 +8,13 @@ import pytest
 
 
 def test_simple_driver():
-    sandbox = e3.anod.sandbox.SandBox()
+    sandbox = e3.anod.sandbox.SandBox(root_dir=os.getcwd())
 
     class Simple(e3.anod.spec.Anod):
         @e3.anod.spec.Anod.primitive()
         def download(self):
             pass
 
-    with pytest.raises(e3.anod.spec.AnodError):
-        anod_instance = Simple(qualifier="", kind="build")
-        anod_instance.sandbox = None
-        e3.anod.driver.AnodDriver(anod_instance=anod_instance, store=None).activate(
-            sandbox, None
-        )
-
-    sandbox.root_dir = os.getcwd()
     anod_instance = Simple(qualifier="", kind="build")
     anod_instance.sandbox = sandbox
     driver = e3.anod.driver.AnodDriver(anod_instance=anod_instance, store=None)
@@ -40,8 +32,7 @@ def test_deps_driver():
         def build(self):
             return self.deps["parent"].parent_info
 
-    sandbox = e3.anod.sandbox.SandBox()
-    sandbox.root_dir = os.getcwd()
+    sandbox = e3.anod.sandbox.SandBox(root_dir=os.getcwd())
     anod_instance = Deps(qualifier="", kind="build")
     anod_instance.sandbox = sandbox
 

--- a/tests/tests_e3/anod/test_sandbox.py
+++ b/tests/tests_e3/anod/test_sandbox.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+import e3.anod.error
 import e3.anod.helper
 import e3.anod.sandbox
 import e3.env
@@ -132,18 +133,13 @@ def test_sandbox_show_config_err():
 
 def test_sandbox_env():
     os.environ["GPR_PROJECT_PATH"] = "/foo"
-    sandbox = e3.anod.sandbox.SandBox()
+    sandbox = e3.anod.sandbox.SandBox(root_dir=os.getcwd())
     sandbox.set_default_env()
     assert os.environ["GPR_PROJECT_PATH"] == ""
 
 
 def test_sandbox_rootdir():
-    sandbox = e3.anod.sandbox.SandBox()
-    with pytest.raises(e3.anod.sandbox.SandBoxError):
-        assert sandbox.root_dir
-
-    sandbox.root_dir = "foo"
-    sandbox.root_dir = "foo"
+    sandbox = e3.anod.sandbox.SandBox(root_dir="foo")
     assert os.path.relpath(sandbox.tmp_dir, sandbox.root_dir) == "tmp"
     assert (
         os.path.relpath(
@@ -610,8 +606,7 @@ def test_sandbox_user_yaml(git_specs_dir):
     assert "build dummyspec" in p.out
     assert f"using alternate specs dir {local_spec_dir}" in p.out
 
-    sbx = e3.anod.sandbox.SandBox()
-    sbx.root_dir = sandbox_dir
+    sbx = e3.anod.sandbox.SandBox(root_dir=sandbox_dir)
 
     assert sbx.is_alternate_specs_dir
 


### PR DESCRIPTION
There is no longer a use case for SandBox not bound to a directory
and forcing root_dir to be set when instantiating the object allows
simplifying type hinting for all *_dir attributes that will never been
set to None.

TN: T707-022