### PR TITLE
Set __specs_dir to None

### DIFF
--- a/src/e3/anod/sandbox/__init__.py
+++ b/src/e3/anod/sandbox/__init__.py
@@ -48,6 +48,7 @@ class SandBox:
         self.patch_dir: str = ""
         self.bin_dir: str = ""
         self.is_alternate_specs_dir = False
+        self.__specs_dir: Optional[str] = None
 
         # Contains the loaded version of user.yaml if present
         self.user_config: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
This is needed when a user.yaml is defined without setting
an alternate specs dir.

TN: T707-022