### PR TITLE
Resolve symbolic links for sandbox root_dir

### DIFF
--- a/src/e3/anod/sandbox/__init__.py
+++ b/src/e3/anod/sandbox/__init__.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 class SandBox:
     def __init__(self, root_dir: str) -> None:
-        self.root_dir: str = root_dir
+        self.root_dir: str = os.path.realpath(root_dir)
         self.build_id: Optional[str] = None
         self.build_date: Optional[str] = None
         self.build_version: Optional[str] = None


### PR DESCRIPTION
Always using real path instead of symbolic links helps us to have
reproducible builds. This was done before the change T707-022, revert
to the previous behavior.

T714-011