### PR TITLE
Fix issue #417: replace `os.rename`

### DIFF
--- a/src/e3/anod/sandbox/migrate.py
+++ b/src/e3/anod/sandbox/migrate.py
@@ -40,6 +40,7 @@ def migrate_v1_5() -> None:
     """
     from glob import glob
     import os
+    from e3.fs import mv
 
     for f in glob("*.yaml"):
         print("looking at %s" % f)
@@ -50,7 +51,7 @@ def migrate_v1_5() -> None:
             except OSError:
                 pass
             try:
-                os.rename(name + ".yaml", os.path.join(name, "config.yaml"))
+                mv(name + ".yaml", os.path.join(name, "config.yaml"))
             except OSError:  # defensive code
                 print("error for %s" % name)
         elif "-" in name:
@@ -64,7 +65,7 @@ def migrate_v1_5() -> None:
                     os.mkdir(prefix)
                 except OSError:  # defensive code
                     pass
-                os.rename(name + ".yaml", os.path.join(prefix, "%s.yaml" % suffix))
+                mv(name + ".yaml", os.path.join(prefix, "%s.yaml" % suffix))
             except Exception as er:  # defensive code
                 print(f"error for {name}.yaml {prefix} {suffix}")
                 print(er)

--- a/src/e3/store/cache/backends/filecache.py
+++ b/src/e3/store/cache/backends/filecache.py
@@ -8,7 +8,7 @@ import time
 from typing import TYPE_CHECKING
 
 import e3.log
-from e3.fs import mkdir, rm
+from e3.fs import mkdir, rm, mv
 from e3.store.cache.backends.base import DEFAULT_TIMEOUT, Cache
 
 try:
@@ -91,7 +91,7 @@ class FileCache(Cache):
                 # atomic rename does not work on windows if the dest file
                 # already exist
                 rm(dest_file)
-            os.rename(tmp_file.name, dest_file)
+            mv(tmp_file.name, dest_file)
             return True
 
         finally:

--- a/tests/fix-coverage-paths.py
+++ b/tests/fix-coverage-paths.py
@@ -6,6 +6,7 @@
 
 
 import os
+import shutil
 import sys
 
 from coverage.sqldata import CoverageData
@@ -21,7 +22,7 @@ def fix_paths(site_pkg_dir, cov_data_file):
 
     old_cov_file = NamedTemporaryFile()
     old_cov_file.close()
-    os.rename(cov_data_file, old_cov_file.name)
+    shutil.move(cov_data_file, old_cov_file.name)
 
     old_coverage_data = CoverageData(old_cov_file.name)
     old_coverage_data.read()

--- a/tests/tests_e3/fs/main_test.py
+++ b/tests/tests_e3/fs/main_test.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import shutil
 
 import e3.diff
 import e3.fs
@@ -253,7 +254,7 @@ def test_sync_tree_case_insensitive():
 
     # Adjust some casing of a file that is up-to-date. Sync_tree should be case
     # preserving and thus adjust the casing
-    os.rename("test/b/OLD2.txt", "test/b/Old2.txt")
+    shutil.move("test/b/OLD2.txt", "test/b/Old2.txt")
     e3.fs.sync_tree("test/a", "test/b")
     assert e3.fs.directory_content("test/b") == e3.fs.directory_content("test/a")
 


### PR DESCRIPTION
Instances of `os.rename` in e3 are replaced to use `e3.fs.mv`, which was
itself written to replace `shutil.move`.

Note that in `e3.fs.mv`, the uses of `os.rename` are retained. Quick
testing suggests that these uses do not cause problems, and the error
behavior of `os.rename` is sufficiently different from `shutil.move`
that I am reluctant to change these uses.

In the test case for `e3.fs`, the use of `os.rename` is replaced with
`shutil.move` - it seemed self-serving to use `e3.fs.mv` here.

Finally, in fix-coverage-paths, the use of `os.rename` is replaced with
`shutil.move`. This script doesn't import e3 at all, so sticking with
python libraries seemed best.