### PR TITLE
Freeze black to 19.10b0 version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands=
 # Use latest supported version of Python to run the style checks
 basepython = python3.8
 deps =
-      black
+      black==19.10b0
       mypy
       flake8
       flake8-bugbear


### PR DESCRIPTION
Black fails with "I/O operation on closed file", see the
reported issue on black: https://github.com/psf/black/issues/1664 