### PR TITLE
Add portable function to check is stdin is a console

### DIFF
--- a/src/e3/os/windows/native_api.py
+++ b/src/e3/os/windows/native_api.py
@@ -227,6 +227,14 @@ class FileInfo:
             return result
 
 
+class ObjectInfo:
+    """Declaration of structures returned by QueryObjectInformation."""
+
+    class Name(Structure):
+        _fields_: List = []
+        class_id = 1
+
+
 class ProcessInfo:
     """Declaration of structure returned by QueryInformationProcess."""
 
@@ -290,6 +298,7 @@ class NT:
     QueryInformationProcess = None
     WaitForMultipleObjects = None
     OpenProcess = None
+    QueryObject = None
 
     @classmethod
     def init_api(cls):
@@ -320,6 +329,10 @@ class NT:
             ULONG,
             INT,
         ]
+        cls.QueryObject = ntdll.NtQueryObject
+        cls.QueryObject.restype = NTSTATUS
+        cls.QueryObject.argtypes = [HANDLE, INT, LPVOID, ULONG, LPVOID]
+
         cls.QueryAttributesFile = ntdll.NtQueryAttributesFile
         cls.QueryAttributesFile.restype = NTSTATUS
         cls.QueryAttributesFile.argtypes = [

--- a/src/e3/os/windows/object.py
+++ b/src/e3/os/windows/object.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import struct
+from e3.os.windows.native_api import NT, ObjectInfo
+from ctypes.wintypes import HANDLE
+from ctypes import create_string_buffer
+
+
+def object_name(handle: HANDLE) -> str:
+    """Given a handle return the windows object name.
+
+    :param handle: object handler
+    :return: the windows object name. If no name can be computed the empty
+        string is returned.
+    """
+    # Return result is a UNICODE_STRING structure followed by
+    # the buffer of the UNICODE_STRING.
+    header_size = struct.calcsize("HHP")
+    buf_size = 32768 + header_size
+    buf = create_string_buffer(buf_size)
+    status = NT.QueryObject(
+        handle, ObjectInfo.Name.class_id, buf, buf_size, 0
+    )  # type: ignore
+    if status < 0:
+        return ""
+
+    str_len, _, _ = struct.unpack_from("HHP", buf.raw, 0)
+    return buf.raw[header_size : header_size + str_len].decode("utf-16-le")

--- a/src/e3/sys.py
+++ b/src/e3/sys.py
@@ -318,3 +318,31 @@ def python_script(name: str, prefix: Optional[str] = None) -> List[str]:
             return [interpreter(prefix), script]
     else:
         return [interpreter(prefix), os.path.join(prefix, "bin", name)]
+
+
+def is_console() -> bool:
+    """Check if stdin is a console or not.
+
+    :return: True if stdin is an interactive console
+    """
+    stdin_fd = sys.stdin.fileno()
+
+    # First check using isatty call. On Windows isatty will return True only
+    # if in a Win32 console (for example cygwin or msys ptys are not win32
+    # consoles).
+    is_tty = os.isatty(stdin_fd)
+    if is_tty:
+        return True
+
+    if sys.platform == "win32":  # unix: no cover
+
+        from msvcrt import get_osfhandle
+        from e3.os.windows.object import object_name
+
+        stdin_name = object_name(get_osfhandle(stdin_fd))
+        if re.match(r"\\Device\\NamedPipe\\(cygwin|msys).*-pty.*$", stdin_name):
+            return True
+        else:
+            return False
+    else:  # win32: no cover
+        return False


### PR DESCRIPTION
Using isatty does not return always the expected result on Windows
platform. Indeed systems such as Cygwin or MSYS do not always use
an underlying win32 console (i.e: they implement their own version
of the unix PTYs using named pipes).

Part of T826-021