### PR TITLE
Force subclassing SpecConfig to pass data to prolog.py

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Minor backward incompatible changes:
   * the discrimiant ``is_virtual`` has been removed
   * e3.anod.sandbox.SandBox now has a mandatory root_dir attribute
+  * AnodSpecRepositories spec_config should now subclass SpecConfig
 
 # Version 22.1.0 (2020-06-22)
 

--- a/src/e3/anod/loader.py
+++ b/src/e3/anod/loader.py
@@ -4,8 +4,8 @@ import inspect
 import os
 import sys
 import types
-
 import yaml
+
 from typing import TYPE_CHECKING
 
 import e3.hash
@@ -22,6 +22,20 @@ if TYPE_CHECKING:
     from e3.anod.spec import Anod
 
 
+class SpecConfig:
+    """Contain specification files configuration.
+
+    :ivar spec_dir: path to the anod specs
+    :ivar repositories: dict containing the list of repositories metadata
+        (content of config/repositories)
+    """
+
+    def __init__(self) -> None:
+        # Both values are set by AnodSpecRepository init
+        self.spec_dir = ""
+        self.repositories: Dict[str, Any] = {}
+
+
 class AnodSpecRepository:
     """Anod spec repository.
 
@@ -33,12 +47,22 @@ class AnodSpecRepository:
     files.
     """
 
-    def __init__(self, spec_dir: str, spec_config: Any = None):
+    def __init__(
+        self,
+        spec_dir: str,
+        spec_config: Any = None,
+        # Ideally should be spec_config: Optional[SpecConfig] = None,
+        # We keep it to Any to avoid mypy issues on other projects
+        extra_repositories_config: Optional[dict] = None,
+    ):
         """Initialize an AnodSpecRepository.
 
         :param spec_dir: directory containing the anod specs.
         :param spec_config: dictionary containing the configuration for this
             AnodSpecRepository
+        :param extra_repositories_config: first read the configuration from
+            <spec_dir>/config/repositories.yaml and update the result with
+            extra_repositories_config
         """
         logger.debug("initialize spec repository (%s)", spec_dir)
 
@@ -97,6 +121,18 @@ class AnodSpecRepository:
         if os.path.isfile(repo_file):
             with open(repo_file) as fd:
                 self.repos = yaml.safe_load(fd)
+
+        if extra_repositories_config:
+            for repo_name, repo_data in extra_repositories_config.items():
+                if repo_name in self.repos:
+                    self.repos[repo_name].update(repo_data)
+                else:
+                    self.repos[repo_name] = repo_data
+
+        if spec_config is None:
+            spec_config = SpecConfig()
+        spec_config.spec_dir = self.spec_dir
+        spec_config.repositories = self.repos
 
         # Declare spec prolog
         prolog_file = os.path.join(spec_dir, "prolog.py")

--- a/src/e3/anod/loader.py
+++ b/src/e3/anod/loader.py
@@ -129,6 +129,11 @@ class AnodSpecRepository:
                 else:
                     self.repos[repo_name] = repo_data
 
+        # Make sure that all revision are strings and not floats
+        for repo_conf in self.repos.values():
+            if "revision" in repo_conf:
+                repo_conf["revision"] = str(repo_conf["revision"])
+
         if spec_config is None:
             spec_config = SpecConfig()
         spec_config.spec_dir = self.spec_dir

--- a/tests/tests_e3/anod/data/config/repositories.yaml.tmpl
+++ b/tests/tests_e3/anod/data/config/repositories.yaml.tmpl
@@ -1,0 +1,4 @@
+e3-core:
+    vcs: git
+    url: git@github.com:AdaCore/e3-core
+    revision: 20.1

--- a/tests/tests_e3/anod/data/prolog.py
+++ b/tests/tests_e3/anod/data/prolog.py
@@ -5,3 +5,6 @@ if "spec_config" not in globals():
 
 if spec_config is not None:
     PROLOG_WAS_EXECUTED = True  # type: ignore
+    E3_CORE_REVISION = spec_config.repositories.get("e3-core", {}).get("revision")
+    E3_EXTRA_REVISION = spec_config.repositories.get("e3-extra", {}).get("revision")
+    FOO = getattr(spec_config, "foo", None)

--- a/tests/tests_e3/anod/data/prolog_test.anod
+++ b/tests/tests_e3/anod/data/prolog_test.anod
@@ -3,3 +3,6 @@ from e3.anod.spec import Anod
 
 class PrologTest(Anod):
     prolog_test = PROLOG_WAS_EXECUTED
+    e3_version = E3_CORE_REVISION
+    e3_extra_version = E3_EXTRA_REVISION
+    has_foo = FOO is not None

--- a/tests/tests_e3/anod/loader_test.py
+++ b/tests/tests_e3/anod/loader_test.py
@@ -40,7 +40,7 @@ class TestLoader:
         assert "invalid spec code" in str(err.value)
 
     def test_spec_loader_prolog(self):
-        spec_repo = AnodSpecRepository(self.spec_dir, spec_config=True)
+        spec_repo = AnodSpecRepository(self.spec_dir)
         anod_class = spec_repo.load("prolog_test")
 
         # We should be able to load a spec twice


### PR DESCRIPTION
Maintaining code based on e3-core is much easier if data are well typed. SpecConfig being on type Any makes it harder to verify that there is no obvious bug in the application. Also having a clearer interface helps teams maintaining anod specification files.

Note that this is a slight backward incompatible change.