### PR TITLE
Refactor code: create a subclass PlanActionEnv

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
   * the discrimiant ``is_virtual`` has been removed
   * e3.anod.sandbox.SandBox now has a mandatory root_dir attribute
   * AnodSpecRepositories spec_config should now subclass SpecConfig
+  * PlanContext now returns PlanActionEnv, a subclass of BaseEnv. Contrary
+    to the previous BaseEnv objects, returned PlanActionEnv always have
+    the following attributes set: "push_to_store", "default_build",
+    "module", "source_packages"
 
 # Version 22.1.0 (2020-06-22)
 

--- a/src/e3/electrolyt/host.py
+++ b/src/e3/electrolyt/host.py
@@ -26,7 +26,7 @@ class Host(BaseEnv):
         :param kwargs: additional user defined data. each key from the data
             dict is accessible like a regular attribute.
         """
-        BaseEnv.__init__(self)
+        super().__init__()
         self.set_build(name=str(platform), version=str(version), machine=str(hostname))
         self._instance.update(kwargs)
 

--- a/src/e3/env.py
+++ b/src/e3/env.py
@@ -20,7 +20,7 @@ from e3.platform import Platform
 
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Iterable, List, Optional, Union
+    from typing import Any, Dict, Iterable, List, Optional, Type, TypeVar, Union
     from argparse import Namespace
 
 logger = e3.log.getLogger("env")
@@ -539,6 +539,10 @@ class AbstractBaseEnv(metaclass=abc.ABCMeta):
             return e
 
 
+if TYPE_CHECKING:
+    BaseEnv_T = TypeVar("BaseEnv_T", bound="BaseEnv")
+
+
 class BaseEnv(AbstractBaseEnv):
     """BaseEnv."""
 
@@ -584,11 +588,11 @@ class BaseEnv(AbstractBaseEnv):
         return iter(self._instance.items())
 
     def copy(
-        self,
+        self: BaseEnv_T,
         build: Optional[str] = None,
         host: Optional[str] = None,
         target: Optional[str] = None,
-    ) -> BaseEnv:
+    ) -> BaseEnv_T:
         """Copy an env.
 
         :param build: like build set_env parameter
@@ -596,22 +600,24 @@ class BaseEnv(AbstractBaseEnv):
         :param target: like target set_env parameter
         :return: a deep copy of the current env
         """
-        result = BaseEnv()
+        result = self.__class__()
         for k, v in self._items():
             setattr(result, k, v)
         result.set_env(build, host, target)
         return result
 
     @classmethod
-    def from_env(cls, env: Optional[Union[Env, BaseEnv]] = None) -> BaseEnv:
+    def from_env(
+        cls: Type[BaseEnv_T], env: Optional[Union[Env, BaseEnv]] = None
+    ) -> BaseEnv_T:
         """Return a new BaseEnv object from an env.
 
         :param env: env. If None copy the current Env
         """
         if env is None:
-            return BaseEnv(build=Env().build, host=Env().host, target=Env().target)
+            return cls(build=Env().build, host=Env().host, target=Env().target)
         else:
-            return BaseEnv(build=env.build, host=env.host, target=env.target)
+            return cls(build=env.build, host=env.host, target=env.target)
 
 
 class Env(AbstractBaseEnv):

--- a/tests/tests_e3/anod/context_test.py
+++ b/tests/tests_e3/anod/context_test.py
@@ -443,15 +443,7 @@ class TestContext:
 
         # Execute the plan and create anod actions
         for action in cm.execute(myplan, "myserver"):
-            primitive = action.action.replace("anod_", "", 1)
-            ac.add_anod_action(
-                name=action.module,
-                env=current_env if action.default_build else action,
-                primitive=primitive,
-                qualifier=action.qualifier,
-                plan_line=action.plan_line,
-                plan_args=action.plan_args,
-            )
+            ac.add_plan_action(action)
 
         # Create a reverse tag to have a working get_context
         # when looking for parameters such as weathers we want to
@@ -566,15 +558,7 @@ class TestContext:
 
         # Execute the plan and create anod actions
         for action in cm.execute(myplan, "myserver"):
-            primitive = action.action.replace("anod_", "", 1)
-            ac.add_anod_action(
-                name=action.module,
-                env=current_env if action.default_build else action,
-                primitive=primitive,
-                qualifier=action.qualifier,
-                plan_line=action.plan_line,
-                plan_args=action.plan_args,
-            )
+            ac.add_plan_action(action)
 
         for uid, _ in ac.tree:
             if uid.endswith("sources"):
@@ -634,15 +618,7 @@ class TestContext:
             # Execute the plan and create anod actions
             # Execute the plan and create anod actions
             for action in cm.execute(myplan, "myserver"):
-                primitive = action.action.replace("anod_", "", 1)
-                ac.add_anod_action(
-                    name=action.module,
-                    env=current_env if action.default_build else action,
-                    primitive=primitive,
-                    qualifier=action.qualifier,
-                    plan_line=action.plan_line,
-                    plan_args=action.plan_args,
-                )
+                ac.add_plan_action(action)
 
             for uid, _ in ac.tree:
                 if uid.endswith("build"):
@@ -651,15 +627,7 @@ class TestContext:
 
             with pytest.raises(SchedulingError):
                 for action in cm.execute(myplan, "myserver"):
-                    primitive = action.action.replace("anod_", "", 1)
-                    ac.add_anod_action(
-                        name=action.module,
-                        env=current_env if action.default_build else action,
-                        primitive=primitive,
-                        qualifier=action.qualifier,
-                        plan_line=action.plan_line,
-                        plan_args=action.plan_args,
-                    )
+                    ac.add_plan_action(action)
 
     def test_plan_call_args(self):
         """Retrieve call args values."""


### PR DESCRIPTION
Instead of using directly BaseEnv to contain the action environment
(including the name of the action, the qualifier, ...), create a
new subclass PlanActionEnv. This hopefully make the code clearer.

Also change e3.env.BaseEnv type annotations to make it possible to
subclass BaseEnv and keep mypy happy.

add_action_action env parameter is renamed action_env to make it clear
that we're not manipulating BaseEnv objects but PlanActionEnv objects.

TN: T107-002