### PR TITLE
Improve error messages in case of patching error

### DIFF
--- a/src/e3/diff.py
+++ b/src/e3/diff.py
@@ -111,7 +111,7 @@ def patch(
         if p.status != 0:
             raise DiffError(
                 origin="patch",
-                message="running %s < %s in %s failed with %s"
+                message="running %s < %s in %s failed with:\n%s"
                 % (" ".join(cmd), fname, working_dir, p.out),
             )
         logger.debug(p.out)


### PR DESCRIPTION
The current output is misleading:

    e3.diff.DiffError: patch: running patch -p0 -f < [patchname]
    in [dir] failed with patching file file1
    patching file file2
    [...]
    <error>

It is all too easy to think that the error occurs when patching file1,
especially if the real error is not immediately visible.