### PR TITLE
Simplify anod primitives exception handling

### DIFF
--- a/src/e3/anod/spec.py
+++ b/src/e3/anod/spec.py
@@ -344,17 +344,10 @@ class Anod:
 
                     # And return the result
                     return result
-                except AnodError:
-                    self.log.exception("%s %s fails", self.name, f.__name__)
-                    raise AnodError(
-                        f"{self.name} {f.__name__} fails "
-                        "(AnodError exception in primitive)"
-                    )
-                except Exception as e:
-                    self.log.exception("%s %s fails", self.name, f.__name__)
-                    raise AnodError(
-                        f"{self.name} {f.__name__} fails (got exception: {e})"
-                    )
+                except Exception:
+                    error_msg = f"{self.name} {f.__name__} fails"
+                    self.log.exception(error_msg)
+                    raise AnodError(error_msg) from None
 
             primitive_func.is_primitive = True
             primitive_func.pre = pre

--- a/tests/tests_e3/anod/spec_test.py
+++ b/tests/tests_e3/anod/spec_test.py
@@ -110,9 +110,8 @@ def test_primitive():
 
     with_primitive2.build_space.create()
 
-    with pytest.raises(AnodError) as err:
+    with pytest.raises(AnodError):
         with_primitive2.build()
-    assert "foobar" in str(err.value)
 
     assert with_primitive2.package.name.startswith("mypackage")
 
@@ -121,9 +120,8 @@ def test_primitive():
     assert with_primitive2["PKG_DIR"].endswith("pkg")
 
     with_primitive3.build_space.create()
-    with pytest.raises(AnodError) as err:
+    with pytest.raises(AnodError):
         with_primitive3.build()
-    assert "build fails" in str(err.value)
 
 
 def test_api_version():


### PR DESCRIPTION
No need to propagate the exception given it's already logged
by self.log.exception.

TN: SC06-023