### PR TITLE
Set 'x86_64-windows64' as default platform for windows

### DIFF
--- a/src/e3/platform_db/knowledge_base.py
+++ b/src/e3/platform_db/knowledge_base.py
@@ -171,5 +171,6 @@ HOST_GUESS: PlatformDBEntry = {
     "x86_64-linux": {"os": "Linux", "cpu": "x86_64"},
     "sparc-solaris": {"os": "SunOS", "cpu": "sparc"},
     "x86-solaris": {"os": "SunOS", "cpu": "i386"},
+    "x86_64-windows64": {"os": "Windows", "cpu": None},
     "x86-windows": {"os": "Windows", "cpu": None},
 }


### PR DESCRIPTION
A new entry was added to platform knowledge_base in order to
make 'x86_64-windows64' the default build platform for windows.