### PR TITLE
Add fallback in case __main__ module has no __file__ attribute

### DIFF
--- a/src/e3/main.py
+++ b/src/e3/main.py
@@ -78,8 +78,10 @@ class Main:
 
         if name is not None:
             self.name = name
-        else:
+        elif hasattr(main, "__file__"):
             self.name = os.path.splitext(os.path.basename(main.__file__))[0]
+        else:
+            self.name = "unknown"
 
         if argument_parser is None:
             argument_parser = ArgumentParser()


### PR DESCRIPTION
This can occurs for example when using python -c.