### PR TITLE
Improve detection of patch for which git apply should be used

### DIFF
--- a/src/e3/diff.py
+++ b/src/e3/diff.py
@@ -100,11 +100,14 @@ def patch(
     :param filtered_patch: name of the filtered patch. By default append
         '.filtered' to the patch_file name
     """
+    # Detect if we can use git apply. I.e if the patch was generated with git
+    # with default prefixes.
     is_git_patch = False
+
     with open(patch_file) as f:
-        first_line = f.readline()
-    if first_line.startswith("diff --git"):
-        is_git_patch = True
+        content = f.read()
+        if re.search(r"^diff --git a/.* b/", content, flags=re.M):
+            is_git_patch = True
 
     def apply_patch(fname: str) -> None:
         """Run the patch command.

--- a/tests/tests_e3/diff/git_diff_no_prefix.patch
+++ b/tests/tests_e3/diff/git_diff_no_prefix.patch
@@ -1,0 +1,8 @@
+diff --git git_file.txt git_file.txt
+index 00c8dcd..7ac8a3e 100644
+--- git_file.txt
++++ git_file.txt
+@@ -1 +1,3 @@
+ This is file that will be patched using git diff format !
++
++That's nice it's working !

--- a/tests/tests_e3/diff/git_diff_show.patch
+++ b/tests/tests_e3/diff/git_diff_show.patch
@@ -1,0 +1,12 @@
+commit blabla
+  
+   some other comments
+
+diff --git a/git_file.txt b/git_file.txt
+index 00c8dcd..7ac8a3e 100644
+--- a/git_file.txt
++++ b/git_file.txt
+@@ -1 +1,3 @@
+ This is file that will be patched using git diff format !
++
++That's nice it's working !

--- a/tests/tests_e3/diff/main_test.py
+++ b/tests/tests_e3/diff/main_test.py
@@ -132,7 +132,7 @@ def test_patch_git_format():
 def test_patch_git_format_ignore():
     test_dir = os.path.dirname(__file__)
     file_to_patch = os.path.join(test_dir, "git_file.txt")
-    patch_file = os.path.join(test_dir, "git_diff.patch")
+    patch_file = os.path.join(test_dir, "*.patch")
 
     cwd = os.getcwd()
 
@@ -149,6 +149,18 @@ def test_patch_git_format_ignore():
     with open(os.path.join(cwd, "git_file.txt")) as fd:
         content = fd.read()
     assert "That's nice it's working !" not in content
+
+    e3.fs.cp(file_to_patch, cwd)
+    e3.diff.patch("git_diff_show.patch", cwd)
+    with open(os.path.join(cwd, "git_file.txt")) as fd:
+        content = fd.read()
+    assert "That's nice it's working !" in content
+
+    e3.fs.cp(file_to_patch, cwd)
+    e3.diff.patch("git_diff_no_prefix.patch", cwd)
+    with open(os.path.join(cwd, "git_file.txt")) as fd:
+        content = fd.read()
+    assert "That's nice it's working !" in content
 
 
 def test_patch_git_with_headers():


### PR DESCRIPTION
* patch generated with git show do not have diff --git as first line.
  Now consider any patch with a line starting with diff --git as a git
  patch
* use git apply only if we are sure user did not removed/adjusted
  the default prefix used when doing git diff or git show

Part of TC02-014