### PR TITLE
Warn on missing source dependencies

### DIFF
--- a/src/e3/anod/context.py
+++ b/src/e3/anod/context.py
@@ -617,6 +617,10 @@ class AnodContext:
         ):
             spec_dependencies += getattr(spec, f"{primitive}_deps")
 
+        source_spec_dependencies_names = {
+            d.name for d in spec_dependencies if d.kind == "source"
+        }
+
         for e in spec_dependencies:
             if isinstance(e, Dependency):
                 if e.kind == "source":
@@ -676,7 +680,18 @@ class AnodContext:
             for s in source_list:
                 # set source builder
                 if s.name in self.sources:
-                    s.set_builder(self.sources[s.name])
+                    sb_spec, sb = self.sources[s.name]
+                    if (
+                        sb_spec != spec.name
+                        and sb_spec not in source_spec_dependencies_names
+                    ):
+                        logger.warning(
+                            f"{spec.name}.anod ({primitive}): source {s.name}"
+                            f" coming from {sb_spec} but there is no"
+                            f" source_pkg dependency for {sb_spec} in {primitive}_deps",
+                        )
+                    s.set_builder(sb)
+
                 # set other sources to compute source ignore
                 s.set_other_sources(source_list)
                 # add source install node

--- a/tests/tests_e3/anod/context_data/missing_src_pkg_dep.anod
+++ b/tests/tests_e3/anod/context_data/missing_src_pkg_dep.anod
@@ -1,0 +1,14 @@
+from e3.anod.spec import Anod
+
+
+class MissingSrcPkgDep(Anod):
+
+    build_deps = [
+        Anod.Dependency("missing_src_pkg_dep_src")]
+
+    build_source_list = [
+        Anod.Source("a-src", dest="", publish=False)]
+
+    @Anod.primitive()
+    def build(self):
+        pass

--- a/tests/tests_e3/anod/context_data/missing_src_pkg_dep_src.anod
+++ b/tests/tests_e3/anod/context_data/missing_src_pkg_dep_src.anod
@@ -1,0 +1,13 @@
+from e3.anod.spec import Anod
+from e3.anod.package import SourceBuilder
+
+
+class SpecManagedSource(Anod):
+
+    source_pkg_build = [
+        SourceBuilder(
+            name='a-src', fullname=lambda: 'a-src.tgz', checkout=['a-git'])]
+
+    @Anod.primitive()
+    def build(self):
+        pass

--- a/tests/tests_e3/anod/context_test.py
+++ b/tests/tests_e3/anod/context_test.py
@@ -660,3 +660,12 @@ class TestContext:
             "The spec duplicate_dep has two dependencies with the same "
             "local_name attribute (spec3)" in str(err)
         )
+
+    def test_add_anod_action_missing_src_pkg_dep(self, caplog):
+        ac = self.create_context()
+        ac.add_anod_action("missing_src_pkg_dep", env=ac.default_env, primitive="build")
+        assert (
+            "source a-src coming from missing_src_pkg_dep_src"
+            " but there is no source_pkg dependency for"
+            " missing_src_pkg_dep_src in build_deps" in caplog.text
+        )


### PR DESCRIPTION
When a source package is used by the spec, the spec needs to have
visibility on its source builder. This can be done either by having
the source builder defined on the same spec, or by adding a "source_pkg"
dependency to the spec defining the source builder.

Also fix the call to set_builder that should take a SourceBuilder
object.

TN: TB05-005