### PR TITLE
Reserve use of Anod name for the base Anod class

### DIFF
--- a/src/e3/anod/loader.py
+++ b/src/e3/anod/loader.py
@@ -241,6 +241,13 @@ class AnodModule:
                 and value.__module__ == mod_name
                 and "Anod" in (k.__name__ for k in value.__mro__)
             ):
+                # Reject class named "Anod" this is reserved to the base
+                # class and can cause some issues when reused
+                if value.__name__ == "Anod":
+                    raise SandBoxError(
+                        f"{self.name}.anod must not use Anod as a class name", "load"
+                    )
+
                 # This class is a child of Anod so register it.
                 # Note that even if we won't use directly the
                 # module we need to keep a reference on it in order

--- a/src/e3/anod/loader.py
+++ b/src/e3/anod/loader.py
@@ -264,7 +264,7 @@ class AnodModule:
                 self.anod_class.api_version = repository.api_version  # type: ignore
                 return value
 
-        logger.error("spec %s does not contains an Anod subclass", self.name)
+        logger.error(f"spec {self.name} does not contains an Anod subclass")
         raise SandBoxError(f"cannot find Anod subclass in {self.path}", "load")
 
 

--- a/tests/tests_e3/anod/data/reuse_anod.anod
+++ b/tests/tests_e3/anod/data/reuse_anod.anod
@@ -1,0 +1,5 @@
+from e3.anod.spec import Anod
+
+
+class Anod(Anod):
+    pass

--- a/tests/tests_e3/anod/loader_test.py
+++ b/tests/tests_e3/anod/loader_test.py
@@ -143,3 +143,10 @@ class TestLoader:
         anod_class = spec_repo.load("parent")
         anod_instance = anod_class("", "build")
         assert anod_instance["PKG_DIR"] == "unknown"
+
+    def test_reuse_anod(self):
+        """Reject spec reusing Anod class name."""
+        spec_repo = AnodSpecRepository(self.spec_dir)
+        with pytest.raises(SandBoxError) as err:
+            spec_repo.load("reuse_anod")
+        assert "must not use Anod" in str(err)

--- a/tests/tests_e3/anod/specs/anod.anod
+++ b/tests/tests_e3/anod/specs/anod.anod
@@ -3,7 +3,7 @@ import os
 import e3.anod.spec
 
 
-class Anod(e3.anod.spec.Anod):
+class Anod_(e3.anod.spec.Anod):
 
     def setenv(self):
         """Add the install directory to PATH."""


### PR DESCRIPTION
We have some code that explicitly ignore class named "Anod" and it's probably better to reject redefinition of Anod class to avoid confusion.