### PR TITLE
Test if spec has the requested primitive right after loading it

### DIFF
--- a/src/e3/anod/context.py
+++ b/src/e3/anod/context.py
@@ -465,6 +465,9 @@ class AnodContext:
 
         # Initialize the resulting action based on the primitive name
         if primitive == "source":
+            if not has_primitive(spec, "source"):
+                raise SchedulingError(f"spec {name} does not support primitive source")
+
             if source_name is not None:
                 result = CreateSource(spec, source_name)
 

--- a/tests/tests_e3/anod/context_data/missing_source_primitive.anod
+++ b/tests/tests_e3/anod/context_data/missing_source_primitive.anod
@@ -1,0 +1,14 @@
+from e3.anod.spec import Anod
+
+
+class MissingSourcePrimitive(Anod):
+    """Missing source_pkg_build (source primitive), so shouldn't be able to perform
+    `anod source`"""
+
+    @Anod.primitive()
+    def build(self):
+        print("build")
+
+    @Anod.primitive()
+    def install(self):
+        print("install")

--- a/tests/tests_e3/anod/context_test.py
+++ b/tests/tests_e3/anod/context_test.py
@@ -367,6 +367,23 @@ class TestContext:
         assert "mylinux.x86-linux.spec13.download_bin" in keys
         assert "mylinux.x86-linux.spec13.install" in keys
 
+    def test_source_fails_when_missing_source_primitive(self):
+        """Source action should fail when the source primitive is undefined.
+
+        Check that a SchedulingError is thrown if the source primitive is absent and a
+        source packaging action is required.
+        """
+        ac = self.create_context()
+
+        # `anod source` should fail on a spec without a source primitive
+        with pytest.raises(
+            SchedulingError,
+            match=r"spec missing_source_primitive does not support primitive source",
+        ):
+            ac.add_anod_action(
+                "missing_source_primitive", env=ac.default_env, primitive="source"
+            )
+
     def test_add_anod_action_unmanaged_source(self):
         """Check no source creation for thirdparties."""
         ac = self.create_context()


### PR DESCRIPTION
The specs that do not define a source (source_pkg_build) primitive fail
with an unhelpful message, because the `has_primitive()` check was
being done too late.

TN: U106-029