### PR TITLE
Add a tmp_dir_root argument to unpack_archive

### DIFF
--- a/src/e3/archive.py
+++ b/src/e3/archive.py
@@ -133,6 +133,7 @@ def unpack_archive(
     delete: bool = False,
     ignore: Optional[list[str]] = None,
     preserve_timestamps: bool = True,
+    tmp_dir_root: Optional[str] = None,
 ) -> None:
     """Unpack an archive file (.tgz, .tar.gz, .tar or .zip).
 
@@ -159,6 +160,10 @@ def unpack_archive(
     :param preserve_timestamps: if False and remove_root_dir is True, and the
         target directory exists, ensure that updated files get their timestamp
         updated to current time.
+    :param tmp_dir_root: If not None the temporary directory used to extract the
+        archive will be created in tmp_dir_root directory. If None the temporary
+        directory is created in the destination directory. This argument only
+        has an effect when remove_root_dir is True.
 
     :raise ArchiveError: in case of error
 
@@ -194,9 +199,9 @@ def unpack_archive(
     # If remove_root_dir is set then extract to a temp directory first.
     # Otherwise extract directly to the final destination
     if remove_root_dir:
-        tmp_dest = tempfile.mkdtemp(
-            prefix="", dir=os.path.dirname(os.path.abspath(dest))
-        )
+        if tmp_dir_root is None:
+            tmp_dir_root = os.path.dirname(os.path.abspath(dest))
+        tmp_dest = tempfile.mkdtemp(prefix="", dir=tmp_dir_root)
     else:
         tmp_dest = dest
 

--- a/tests/tests_e3/archive/main_test.py
+++ b/tests/tests_e3/archive/main_test.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import tempfile
 
 import e3.archive
 import e3.fs
@@ -7,6 +8,7 @@ import e3.log
 import e3.os.fs
 
 import pytest
+from unittest.mock import patch
 
 
 @pytest.mark.parametrize("ext", (".tar.gz", ".tar.bz2", ".tar", ".zip"))
@@ -240,6 +242,21 @@ def test_remove_root_dir():
         os.path.join("dest", "pkg.zip"), "result", remove_root_dir="auto"
     )
     assert os.path.exists(os.path.join("result", "from", "a"))
+
+
+@patch("tempfile.mkdtemp", wraps=tempfile.mkdtemp)
+def test_tmp_dir_root(mock_mkdtemp):
+    """Try to unpack an archive with remove_root_dir and a custom tmp_dir root."""
+    e3.fs.mkdir("custom_tmp_dir_root")
+    e3.fs.mkdir("result")
+    e3.archive.unpack_archive(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "test.zip"),
+        "result",
+        remove_root_dir=True,
+        tmp_dir_root="custom_tmp_dir_root",
+    )
+    mock_mkdtemp.assert_called_once_with(prefix="", dir="custom_tmp_dir_root")
+    assert os.path.exists("result/test.sh")
 
 
 def test_empty():


### PR DESCRIPTION
This argument can be used to avoid an overly long temporary path when
extracting an archive to remove its root.

TN: U120-025