### PR TITLE
Remove unused force_skip value

### DIFF
--- a/src/e3/anod/status.py
+++ b/src/e3/anod/status.py
@@ -10,7 +10,6 @@ class ReturnValue(IntEnum):
     failure = 1
     missing = 2
     notready = 75
-    force_skip = 122
     force_fail = 123
     unknown = 124
     skip = 125

--- a/src/e3/electrolyt/run.py
+++ b/src/e3/electrolyt/run.py
@@ -210,9 +210,7 @@ class ElectrolytJobFactory:
         self, uid: str, data: Action, predecessors: frozenset[str], notify_end: Callable
     ) -> ElectrolytJob:
         force_fail = any(
-            k
-            for k in predecessors
-            if self.job_status[k] not in (STATUS.success, STATUS.force_skip)
+            k for k in predecessors if self.job_status[k] != STATUS.success
         )
         return ElectrolytJob(
             uid,

--- a/src/e3/job/__init__.py
+++ b/src/e3/job/__init__.py
@@ -187,7 +187,7 @@ class EmptyJob(Job):
         uid: str,
         data: Any,
         notify_end: Callable[[str], None],
-        status: ReturnValue = ReturnValue.force_skip,
+        status: ReturnValue,
     ) -> None:
         """Initialize the EmptyJob.
 

--- a/src/e3/job/walk.py
+++ b/src/e3/job/walk.py
@@ -265,12 +265,7 @@ class Walk:
             k
             for k in predecessors
             if self.job_status[k]
-            not in (
-                ReturnValue.success,
-                ReturnValue.skip,
-                ReturnValue.force_skip,
-                ReturnValue.unchanged,
-            )
+            not in (ReturnValue.success, ReturnValue.skip, ReturnValue.unchanged,)
         ]
         if failed_predecessors:
             force_fail = "Event failed because of prerequisite failure:\n"
@@ -321,7 +316,6 @@ class Walk:
         # to skipping it).
         if job.status in (
             ReturnValue.success,
-            ReturnValue.force_skip,
             ReturnValue.skip,
             ReturnValue.unchanged,
         ):
@@ -331,7 +325,7 @@ class Walk:
         self.job_status[job.uid] = ReturnValue(job.status)
 
         if job.should_skip:
-            if job.status not in (ReturnValue.force_fail, ReturnValue.force_skip):
+            if job.status not in (ReturnValue.force_fail, ReturnValue.skip):
                 logging.info(
                     "[%-10s %-9s %4ds] %s",
                     job.queue_name,

--- a/tests/tests_e3/job/walk_test.py
+++ b/tests/tests_e3/job/walk_test.py
@@ -184,7 +184,7 @@ class SimpleWalk(Walk):
 
     def create_job(self, uid, data, predecessors, notify_end):
         if self.dry_run_mode:
-            job = DryRunJob(uid, data, notify_end, status=ReturnValue.force_skip)
+            job = DryRunJob(uid, data, notify_end, status=ReturnValue.skip)
         elif uid.endswith("do-nothing"):
             job = DoNothingJob(uid, data, notify_end)
         else:
@@ -681,21 +681,21 @@ def test_dry_run(setup_sbx):
     actions.add_vertex("2", predecessors=["1"])
 
     # First run in dry-run mode. Both actions are turned into
-    # empty jobs with a force_skip status.
+    # empty jobs with a skip status.
 
     r1 = FingerprintWalkDryRun(actions)
 
     job = r1.saved_jobs["1"]
     assert isinstance(job, DryRunJob)
     assert job.should_skip is True
-    assert job.status == ReturnValue.force_skip
+    assert job.status == ReturnValue.skip
 
     job = r1.saved_jobs["2"]
     assert isinstance(job, DryRunJob)
     assert job.should_skip is True
-    assert job.status == ReturnValue.force_skip
+    assert job.status == ReturnValue.skip
 
-    assert r1.job_status == {"1": ReturnValue.force_skip, "2": ReturnValue.force_skip}
+    assert r1.job_status == {"1": ReturnValue.skip, "2": ReturnValue.skip}
     assert r1.requeued == {}
 
     # Try it again in dry-mode; we should get the same result.
@@ -705,14 +705,14 @@ def test_dry_run(setup_sbx):
     job = r2.saved_jobs["1"]
     assert isinstance(job, DryRunJob)
     assert job.should_skip is True
-    assert job.status == ReturnValue.force_skip
+    assert job.status == ReturnValue.skip
 
     job = r2.saved_jobs["2"]
     assert isinstance(job, DryRunJob)
     assert job.should_skip is True
-    assert job.status == ReturnValue.force_skip
+    assert job.status == ReturnValue.skip
 
-    assert r2.job_status == {"1": ReturnValue.force_skip, "2": ReturnValue.force_skip}
+    assert r2.job_status == {"1": ReturnValue.skip, "2": ReturnValue.skip}
     assert r2.requeued == {}
 
     # Now, get action '1' done in normal (non-dry-run) mode.
@@ -746,9 +746,9 @@ def test_dry_run(setup_sbx):
     job = r4.saved_jobs["2"]
     assert isinstance(job, DryRunJob)
     assert job.should_skip is True
-    assert job.status == ReturnValue.force_skip
+    assert job.status == ReturnValue.skip
 
-    assert r4.job_status == {"1": ReturnValue.skip, "2": ReturnValue.force_skip}
+    assert r4.job_status == {"1": ReturnValue.skip, "2": ReturnValue.skip}
     assert r4.requeued == {}
 
     # Run it again, this time in normal (non-dry-run) mode.


### PR DESCRIPTION
This was meant to be returned by anod action when skip events were
only generated when the action were run. The launcher then spawned
anod action with a specific --force=skip parameter to force a skip
event.

This is not needed anymore.
TN: T501-020