### PR TITLE
Change logging level for nis import error

### DIFF
--- a/src/e3/os/platform.py
+++ b/src/e3/os/platform.py
@@ -109,7 +109,6 @@ class SystemInfo:
             try:
                 import nis
             except ImportError:  # defensive code
-                logger.exception("cannot import nis")
                 nis = None  # type: ignore
 
             if nis is not None:


### PR DESCRIPTION
We put back the logging level to debug as there
are some tools that rely on the output of platform
module.

TN: U330-058