### PR TITLE
Add a new anod dependency kind: download

### DIFF
--- a/src/e3/anod/deps.py
+++ b/src/e3/anod/deps.py
@@ -45,6 +45,7 @@ class Dependency:
         local_name: Optional[str] = None,
         require: Literal["build_tree"]
         | Literal["installation"]
+        | Literal["download"]
         | Literal["source_pkg"] = "build_tree",
         track: bool = False,
         **kwargs: Any,
@@ -68,7 +69,7 @@ class Dependency:
             in deps and makedeps dictionaries. It allows importing twice
             the same anod module with different qualifers or platforms
         :param require: can be 'build_tree' (to force a local build),
-            'installation' or 'source_pkg'
+            'installation', 'download', or 'source_pkg'
         :param track: if True, track all source packages metadata and include
             them in the local metadata.
         :param kwargs: other parameters valid in some API that we ignore now
@@ -81,13 +82,15 @@ class Dependency:
         self.build = build
         self.qualifier = qualifier
         self.local_name = local_name if local_name is not None else name
-        if require not in ("build_tree", "installation", "source_pkg"):
+        if require not in ("build_tree", "download", "installation", "source_pkg",):
             raise e3.anod.error.SpecError(
-                "require should be build_tree, installation or source_pkg"
-                " not %s." % require
+                f"require should be build_tree, download, installation,"
+                f" or source_pkg not {require}."
             )
         if require == "build_tree":
             self.kind = "build"
+        elif require == "download":
+            self.kind = "download"
         elif require == "installation":
             self.kind = "install"
         elif require == "source_pkg":

--- a/src/e3/anod/spec.py
+++ b/src/e3/anod/spec.py
@@ -50,10 +50,14 @@ if TYPE_CHECKING:
     SOURCE_PRIMITIVE = Literal["source"]
 
     # Anod Dependency can target a build, install, or source
-    DEPENDENCY_PRIMITIVE = Union[BUILD_PRIMITIVE, INSTALL_PRIMITIVE, SOURCE_PRIMITIVE]
+    DEPENDENCY_PRIMITIVE = Union[
+        BUILD_PRIMITIVE, DOWNLOAD_PRIMITIVE, INSTALL_PRIMITIVE, SOURCE_PRIMITIVE
+    ]
 
     # Supported primitivies are build, install, source, and test
-    PRIMITIVE = Union[DEPENDENCY_PRIMITIVE, TEST_PRIMITIVE]
+    PRIMITIVE = Union[
+        BUILD_PRIMITIVE, INSTALL_PRIMITIVE, SOURCE_PRIMITIVE, TEST_PRIMITIVE
+    ]
 
 
 def check_api_version(version: str) -> None:

--- a/tests/tests_e3/anod/force_download/spec_build.anod
+++ b/tests/tests_e3/anod/force_download/spec_build.anod
@@ -1,0 +1,18 @@
+from e3.anod.spec import Anod
+
+class SpecBuild(Anod):
+    component = 'specbuild'
+
+    package = Anod.Package(prefix='specbuild', version=lambda: '42')
+
+    @Anod.primitive()
+    def build(self):
+        pass
+
+    @Anod.primitive()
+    def install(self):
+        pass
+
+    @Anod.primitive()
+    def download(self):
+        return {'component': 'specbuild_stable'}

--- a/tests/tests_e3/anod/force_download/spec_build_dep.anod
+++ b/tests/tests_e3/anod/force_download/spec_build_dep.anod
@@ -1,0 +1,10 @@
+from e3.anod.spec import Anod
+
+
+class SpecBuildDep(Anod):
+
+    build_deps = [Anod.Dependency("spec_build", require="build_tree")]
+
+    @Anod.primitive()
+    def build(self):
+        pass

--- a/tests/tests_e3/anod/force_download/spec_download_dep.anod
+++ b/tests/tests_e3/anod/force_download/spec_download_dep.anod
@@ -1,0 +1,10 @@
+from e3.anod.spec import Anod
+
+
+class SpecDownloadDep(Anod):
+
+    build_deps = [Anod.Dependency("spec_build", require="download")]
+
+    @Anod.primitive()
+    def build(self):
+        pass

--- a/tests/tests_e3/anod/force_download/spec_download_dep_for_nodownloadprimitive.anod
+++ b/tests/tests_e3/anod/force_download/spec_download_dep_for_nodownloadprimitive.anod
@@ -1,0 +1,10 @@
+from e3.anod.spec import Anod
+
+
+class SpecDownloadDepForNowDownloadPrimitive(Anod):
+
+    build_deps = [Anod.Dependency("spec_nodownloadprimitive", require="download")]
+
+    @Anod.primitive()
+    def build(self):
+        pass

--- a/tests/tests_e3/anod/force_download/spec_install_dep.anod
+++ b/tests/tests_e3/anod/force_download/spec_install_dep.anod
@@ -1,0 +1,10 @@
+from e3.anod.spec import Anod
+
+
+class SpecInstallDep(Anod):
+
+    build_deps = [Anod.Dependency("spec_build", require="installation")]
+
+    @Anod.primitive()
+    def build(self):
+        pass

--- a/tests/tests_e3/anod/force_download/spec_nodownloadprimitive.anod
+++ b/tests/tests_e3/anod/force_download/spec_nodownloadprimitive.anod
@@ -1,0 +1,15 @@
+from e3.anod.spec import Anod
+
+class SpecNoDownloadPrimitive(Anod):
+    component = 'specnodownloadprimitive'
+
+    package = Anod.Package(prefix='specnodownloadprimitive', version=lambda: '42')
+
+    @Anod.primitive()
+    def build(self):
+        pass
+
+    @Anod.primitive()
+    def install(self):
+        pass
+

--- a/tests/tests_e3/anod/force_download_test.py
+++ b/tests/tests_e3/anod/force_download_test.py
@@ -1,0 +1,137 @@
+from e3.env import BaseEnv
+from e3.anod.context import AnodContext, SchedulingError
+from e3.anod.loader import AnodSpecRepository
+import os
+import pytest
+
+
+class TestSourceClosure:
+
+    spec_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "force_download")
+    )
+
+    def test_force_download_after_install(self):
+        """Test two deps on the same spec with installation and download.
+
+        Here we have two specs having an "installation" and a "download"
+        depdendency on the same spec (spec_build). When the two are set
+        together the scheduler find the proper solution: download.
+        """
+        env = BaseEnv()
+        env.set_build("x86_64-linux", "rhes8", "mylinux")
+        asr = AnodSpecRepository(self.spec_dir)
+        ac = AnodContext(asr, default_env=env)
+        ac.add_anod_action("spec_install_dep", env=ac.default_env, primitive="build")
+        with pytest.raises(SchedulingError) as err:
+            ac.schedule(ac.always_create_source_resolver)
+        assert "This plan resolver cannot decide" in str(err)
+
+        ac.add_anod_action("spec_download_dep", env=ac.default_env, primitive="build")
+        result = ac.schedule(ac.always_create_source_resolver)
+
+        assert set(result.vertex_data.keys()) == {
+            "root",
+            "mylinux.x86_64-linux.spec_install_dep.build",
+            "mylinux.x86_64-linux.spec_download_dep.build",
+            "mylinux.x86_64-linux.spec_build.install",
+            "mylinux.x86_64-linux.spec_build.download_bin",
+        }
+
+    def test_force_download_before_install(self):
+        """Test two deps on the same spec with installation and download.
+
+        Same as test_force_download_after_install but in a different
+        order. The end result should be the same.
+        """
+        env = BaseEnv()
+        env.set_build("x86_64-linux", "rhes8", "mylinux")
+        asr = AnodSpecRepository(self.spec_dir)
+        ac = AnodContext(asr, default_env=env)
+        ac.add_anod_action("spec_download_dep", env=ac.default_env, primitive="build")
+        result = ac.schedule(ac.always_create_source_resolver)
+
+        assert set(result.vertex_data.keys()) == {
+            "root",
+            "mylinux.x86_64-linux.spec_download_dep.build",
+            "mylinux.x86_64-linux.spec_build.install",
+            "mylinux.x86_64-linux.spec_build.download_bin",
+        }
+        ac.add_anod_action("spec_install_dep", env=ac.default_env, primitive="build")
+        ac.schedule(ac.always_create_source_resolver)
+        result = ac.schedule(ac.always_create_source_resolver)
+
+        assert set(result.vertex_data.keys()) == {
+            "root",
+            "mylinux.x86_64-linux.spec_install_dep.build",
+            "mylinux.x86_64-linux.spec_download_dep.build",
+            "mylinux.x86_64-linux.spec_build.install",
+            "mylinux.x86_64-linux.spec_build.download_bin",
+        }
+
+    def test_force_download_after_build(self):
+        """Test two deps on the same spec with build and download.
+
+        Here we have two specs having an "build_tree" and a "download"
+        depdendency on the same spec (spec_build). When the two are set
+        together the scheduler cannot find a solution.
+        """
+        env = BaseEnv()
+        env.set_build("x86_64-linux", "rhes8", "mylinux")
+        asr = AnodSpecRepository(self.spec_dir)
+        ac = AnodContext(asr, default_env=env)
+        ac.add_anod_action("spec_build_dep", env=ac.default_env, primitive="build")
+
+        # Verify that, when scheduling this plan, the scheduler ask for
+        # having an explicit build
+        with pytest.raises(SchedulingError) as err:
+            ac.schedule(ac.always_create_source_resolver)
+        assert "A spec in the plan has a build_tree dependency on spec_build" in str(
+            err
+        )
+
+        # Verify that after adding a download dep, the scheduler now
+        # warns that he cannot resolve the plan
+        ac.add_anod_action("spec_download_dep", env=ac.default_env, primitive="build")
+        with pytest.raises(SchedulingError) as err:
+            ac.schedule(ac.always_create_source_resolver)
+        assert "explicit DownloadBinary decision made" in str(err)
+
+    def test_force_download_before_build(self):
+        """Test two deps on the same spec with build and download.
+
+        Same as test_force_download_after_build but in a different order.
+        The expected result is the same: an error should be raised.
+        """
+        env = BaseEnv()
+        env.set_build("x86_64-linux", "rhes8", "mylinux")
+        asr = AnodSpecRepository(self.spec_dir)
+        ac = AnodContext(asr, default_env=env)
+        ac.add_anod_action("spec_download_dep", env=ac.default_env, primitive="build")
+        ac.add_anod_action("spec_build_dep", env=ac.default_env, primitive="build")
+        with pytest.raises(SchedulingError) as err:
+            ac.schedule(ac.always_create_source_resolver)
+        assert "explicit DownloadBinary decision made" in str(err)
+
+    def test_force_download_without_download_primitive(self):
+        """Test that the force download do not require the download primitive.
+
+        Having a download() primitive or not should not impact this feature.
+        """
+        env = BaseEnv()
+        env.set_build("x86_64-linux", "rhes8", "mylinux")
+        asr = AnodSpecRepository(self.spec_dir)
+        ac = AnodContext(asr, default_env=env)
+        ac.add_anod_action(
+            "spec_download_dep_for_nodownloadprimitive",
+            env=ac.default_env,
+            primitive="build",
+        )
+        result = ac.schedule(ac.always_create_source_resolver)
+
+        assert set(result.vertex_data.keys()) == {
+            "root",
+            "mylinux.x86_64-linux.spec_download_dep_for_nodownloadprimitive.build",
+            "mylinux.x86_64-linux.spec_nodownloadprimitive.install",
+            "mylinux.x86_64-linux.spec_nodownloadprimitive.download_bin",
+        }

--- a/tests/tests_e3/anod/spec_test.py
+++ b/tests/tests_e3/anod/spec_test.py
@@ -58,8 +58,8 @@ def test_spec_wrong_dep():
         Anod.Dependency("foo", require="invalid")
 
     assert (
-        "require should be build_tree, installation or source_pkg not "
-        "invalid" in str(err)
+        "require should be build_tree, download, installation,"
+        " or source_pkg not invalid" in str(err)
     )
 
 


### PR DESCRIPTION
When adding a Dependency with require="download" the plan scheduler
forces an installation of the dependency from the downloaded binary
package. If another anod spec has a require="build_tree" dependency
on the same spec then plan scheduler will raise an error.