### PR TITLE
Add a require cond to disable primitive in some context

### DIFF
--- a/src/e3/anod/context.py
+++ b/src/e3/anod/context.py
@@ -505,6 +505,11 @@ class AnodContext:
                     self.connect(result, sub_result)
 
         elif primitive == "build":
+            if not has_primitive(spec, "build"):
+                raise SchedulingError(
+                    f"spec {name} does not support primitive build for"
+                    " platform {env.platform} and qualifier '{qualifier}'"
+                )
             result = Build(spec)
         elif primitive == "test":
             result = Test(spec)

--- a/src/e3/anod/spec.py
+++ b/src/e3/anod/spec.py
@@ -101,7 +101,14 @@ def has_primitive(anod_instance: Anod, name: Literal["download"] | PRIMITIVE) ->
         is_primitive: bool = func.is_primitive
     except AttributeError:
         return False
-    return is_primitive
+
+    if is_primitive:
+        if func.require is None:
+            return True
+        else:
+            return func.require(anod_instance)
+    else:
+        return False
 
 
 def fetch_attr(instance: Any, name: str, default_value: Any) -> Any:
@@ -346,6 +353,7 @@ class Anod:
         pre: Optional[Callable[[Anod], dict]] = None,
         post: Optional[Callable[..., None]] = None,
         version: Optional[Callable[..., str]] = None,
+        require: Optional[Callable[[Anod], bool]] = None,
     ) -> Callable:
         """Declare an anod primitive.
 
@@ -359,6 +367,9 @@ class Anod:
         :param version: None or a callback function returning the version
             that will be evaluated as a string. This callback is called
             after running the primitive
+        :param require: None or a special function to call before running the
+            primitive. The function takes a unique parameter `self` and
+            returns a boolean
         :raise: AnodError
         """
 
@@ -397,6 +408,7 @@ class Anod:
             primitive_func.pre = pre
             primitive_func.post = post
             primitive_func.version = version
+            primitive_func.require = require
             return primitive_func
 
         return primitive_dec

--- a/tests/tests_e3/anod/force_download/spec_nobuild.anod
+++ b/tests/tests_e3/anod/force_download/spec_nobuild.anod
@@ -1,0 +1,14 @@
+from e3.anod.spec import Anod
+
+class SpecNoBuild(Anod):
+    component = 'specnobuild'
+
+    package = Anod.Package(prefix='specnobuild', version=lambda: '42')
+
+    @Anod.primitive(require=lambda x: "stable" not in x.parsed_qualifier)
+    def build(self):
+        pass
+
+    @Anod.primitive()
+    def install(self):
+        pass

--- a/tests/tests_e3/anod/force_download/spec_nobuild_dep.anod
+++ b/tests/tests_e3/anod/force_download/spec_nobuild_dep.anod
@@ -1,0 +1,9 @@
+from e3.anod.spec import Anod
+
+class SpecNoBuildDep(Anod):
+
+    build_deps = [Anod.Dependency("spec_nobuild", require="installation")]
+
+    @Anod.primitive()
+    def build(self):
+        pass

--- a/tests/tests_e3/anod/force_download/spec_nobuild_stable_dep.anod
+++ b/tests/tests_e3/anod/force_download/spec_nobuild_stable_dep.anod
@@ -1,0 +1,9 @@
+from e3.anod.spec import Anod
+
+class SpecNoBuildStableDep(Anod):
+
+    build_deps = [Anod.Dependency("spec_nobuild", qualifier="stable", require="installation")]
+
+    @Anod.primitive()
+    def build(self):
+        pass


### PR DESCRIPTION
Adding @Anod.primitive(require=lambda x: "stable" in x.parsed_qualifier)
for a build primitive will explicitly disable builds when the qualifier
contains "stable".

TN: U410-001