### PR TITLE
remove duplicate "src" entry from BuildSpace.DIRS

### DIFF
--- a/src/e3/anod/buildspace.py
+++ b/src/e3/anod/buildspace.py
@@ -29,7 +29,6 @@ class BuildSpace:
         "src",
         "test",
         "tmp",
-        "src",
     )
 
     def __init__(self, root_dir: str):


### PR DESCRIPTION
I noticed that this class attribute had two identical entries
to it, so this commit removes the one at the end (which seems
to be out of order).