### PR TITLE
If PATHEXT variable is not defined on Windows use .exe rather ""

### DIFF
--- a/src/e3/os/fs.py
+++ b/src/e3/os/fs.py
@@ -327,7 +327,10 @@ def which(prog: str, paths: Optional[str] = None, default: Any = "") -> Any:
         names = [file_path]
         if sys.platform == "win32":  # unix: no cover
             names.extend(
-                [file_path + ext for ext in os.environ.get("PATHEXT", "").split(";")]
+                [
+                    file_path + ext
+                    for ext in os.environ.get("PATHEXT", ".EXE").split(";")
+                ]
             )
         return names
 

--- a/src/e3/sys.py
+++ b/src/e3/sys.py
@@ -298,7 +298,7 @@ def python_script(name: str, prefix: Optional[str] = None) -> list[str]:
         # 3- a .exe without a side python script
         script = (
             os.path.join(prefix, name)
-            if os.path.basename(prefix) == "scripts"
+            if os.path.basename(prefix).lower() == "scripts"
             else os.path.join(prefix, "Scripts", name)
         )
 

--- a/tests/tests_e3/sys/main_test.py
+++ b/tests/tests_e3/sys/main_test.py
@@ -84,9 +84,10 @@ def test_python_func():
             "/foo/python.exe",
             "/foo/Scripts/run",
         ]
+        # Don't check cases as on windows we might get .EXE or .exe
         assert [e3.os.fs.unixpath(p) for p in e3.sys.python_script("run")][
             0
-        ] == e3.os.fs.unixpath(sys.executable)
+        ].lower() == e3.os.fs.unixpath(sys.executable).lower()
 
         e3.fs.mkdir("Scripts")
         e3.os.fs.touch("Scripts/run.exe")


### PR DESCRIPTION
For example on github actions PATHEXT is never defined and assuming an
empty PATHEXT value disable automatic .exe completion on which various
testsuite are relying.