### PR TITLE
Use shallow git fetch if changelog is not computed

### DIFF
--- a/src/e3/anod/checkout.py
+++ b/src/e3/anod/checkout.py
@@ -234,7 +234,21 @@ class CheckoutManager:
             old_commit = g.rev_parse()
 
             # Using fetch + checkout ensure caching is effective
-            g.git_cmd(["fetch", "-f", remote_name, f"{revision}:refs/e3-checkout"])
+            shallow = (
+                "git_shallow_fetch"
+                in os.environ.get("E3_ENABLE_FEATURE", "").split(",")
+                and not self.compute_changelog
+            )
+            g.git_cmd(
+                [
+                    "fetch",
+                    "-f",
+                    "--depth=1" if shallow else None,
+                    remote_name,
+                    f"{revision}:refs/e3-checkout",
+                ]
+            )
+
             g.checkout("refs/e3-checkout", force=True)
             new_commit = g.rev_parse()
 

--- a/tests/tests_e3/anod/checkout_test.py
+++ b/tests/tests_e3/anod/checkout_test.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pytest
 
 from e3.anod.checkout import CheckoutManager
 from e3.anod.status import ReturnValue
@@ -41,11 +42,14 @@ class TestCheckout:
     repo_data = os.path.join(os.path.dirname(__file__), "vcs_data")
     repo_data2 = os.path.join(os.path.dirname(__file__), "vcs_data2")
 
-    def test_svn_checkout(self):
+    @pytest.mark.parametrize("compute_changelog", [True, False])
+    @pytest.mark.parametrize("e3_feature", ["", "git_shallow_fetch"])
+    def test_svn_checkout(self, compute_changelog, e3_feature):
         os.environ["GIT_AUTHOR_EMAIL"] = "e3-core@example.net"
         os.environ["GIT_AUTHOR_NAME"] = "e3 core"
         os.environ["GIT_COMMITTER_NAME"] = "e3-core@example.net"
         os.environ["GIT_COMMITTER_EMAIL"] = "e3 core"
+        os.environ["E3_ENABLE_FEATURE"] = e3_feature
 
         url = SVNRepository.create("svn", initial_content_path=self.repo_data)
         url2 = SVNRepository.create("svn2", initial_content_path=self.repo_data2)
@@ -55,7 +59,9 @@ class TestCheckout:
         r = SVNRepository(working_copy=os.path.abspath("svn_checkout"))
         r.update(url=url)
 
-        m = CheckoutManager(name="myrepo", working_dir=".")
+        m = CheckoutManager(
+            name="myrepo", working_dir=".", compute_changelog=compute_changelog
+        )
 
         logging.info("update of non existing url")
         result = m.update(vcs="svn", url=url + "wrong_url")


### PR DESCRIPTION
If git_shallow_fetch e3 feature is set and changelog does not need to be
computed git fetch is done with a depth of 1. This feature can be used
by CIs to make them faster and fix existing issues with large
repositories.


Part of U831-001