### PR TITLE
Fix raise-missing-from errors

### DIFF
--- a/src/e3/anod/context.py
+++ b/src/e3/anod/context.py
@@ -987,7 +987,7 @@ class AnodContext:
                             ]
                             raise SchedulingError(
                                 e.messages, uid=uid, initiators=initiators
-                            )
+                            ) from e
                 else:
                     # An action is scheduled only if one of its successors is
                     # scheduled.

--- a/src/e3/anod/driver.py
+++ b/src/e3/anod/driver.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from functools import wraps
 from typing import TYPE_CHECKING
 
@@ -92,7 +91,7 @@ class AnodDriver:
             self.anod_instance.log.critical(err)
             raise AnodError(
                 "cannot get resource metadata from store", origin=self.anod_instance.uid
-            ).with_traceback(sys.exc_info()[2])
+            ) from err
         else:
             self.store.download_resource(
                 metadata, self.anod_instance.build_space.binary_dir

--- a/src/e3/anod/loader.py
+++ b/src/e3/anod/loader.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import inspect
 import os
-import sys
 import types
 import yaml
 
@@ -228,7 +227,7 @@ class AnodModule:
             logger.error("cannot load code of %s", self.name)
             raise SandBoxError(
                 origin="load", message=f"invalid spec code for {self.name}"
-            ).with_traceback(sys.exc_info()[2])
+            ) from e
 
         # At this stage we have loaded completely the module. Now we need to
         # look for a subclass of Anod. Use python inspection features to

--- a/src/e3/anod/spec.py
+++ b/src/e3/anod/spec.py
@@ -400,10 +400,10 @@ class Anod:
 
                     # And return the result
                     return result
-                except Exception:
+                except Exception as err:
                     error_msg = f"{self.name} {f.__name__} fails"
                     self.log.exception(error_msg)
-                    raise AnodError(error_msg) from None
+                    raise AnodError(error_msg) from err
 
             primitive_func.is_primitive = True
             primitive_func.pre = pre

--- a/src/e3/archive.py
+++ b/src/e3/archive.py
@@ -279,7 +279,7 @@ def unpack_archive(
                 raise ArchiveError(
                     origin="unpack_archive",
                     message=f"Cannot untar {filename} ({e})",
-                ).with_traceback(sys.exc_info()[2])
+                ) from e
 
         elif ext == "zip":
             try:
@@ -291,7 +291,7 @@ def unpack_archive(
                 raise ArchiveError(
                     origin="unpack_archive",
                     message=f"Cannot unzip {filename} ({e})",
-                ).with_traceback(sys.exc_info()[2])
+                ) from e
         else:
             assert_never()
 

--- a/src/e3/env.py
+++ b/src/e3/env.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import abc
 import os
 import pickle
-import sys
 from collections import namedtuple
 
 from typing import TYPE_CHECKING
@@ -582,7 +581,7 @@ class BaseEnv(AbstractBaseEnv):
         try:
             return self._instance[name]
         except KeyError as e:
-            raise AttributeError(e).with_traceback(sys.exc_info()[2])
+            raise AttributeError(e) from e
 
     def _items(self) -> Iterable[Any]:
         return iter(self._instance.items())
@@ -659,7 +658,7 @@ class Env(AbstractBaseEnv):
         try:
             return self._instance[name]
         except KeyError as e:
-            raise AttributeError(e).with_traceback(sys.exc_info()[2])
+            raise AttributeError(e) from e
 
     def _items(self) -> Iterable[Any]:
         return iter(self._instance.items())

--- a/src/e3/event/__init__.py
+++ b/src/e3/event/__init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import abc
 import json
 import os
-import sys
 import time
 import uuid
 from typing import TYPE_CHECKING
@@ -108,7 +107,7 @@ class Event:
         try:
             return self._data[name]
         except KeyError as e:
-            raise AttributeError(e).with_traceback(sys.exc_info()[2])
+            raise AttributeError(e) from e
 
     def get_attachments(self) -> dict[str, tuple[str, str]]:
         """Return the list of attachments.

--- a/src/e3/fs.py
+++ b/src/e3/fs.py
@@ -93,7 +93,7 @@ def cp(
             logger.error(e, exc_info=True)
             raise FSError(
                 origin="cp", message=f"error occurred while copying {f}"
-            ).with_traceback(sys.exc_info()[2])
+            ) from e
 
 
 def directory_content(
@@ -279,9 +279,7 @@ def mkdir(path: str, mode: int = 0o755, quiet: bool = False) -> None:
                 # existence and the call to makedirs
                 return
             logger.error(e)
-            raise FSError(
-                origin="mkdir", message=f"can't create {path}"
-            ).with_traceback(sys.exc_info()[2])
+            raise FSError(origin="mkdir", message=f"can't create {path}") from e
 
 
 def mv(source: str | list[str], target: str) -> None:
@@ -342,7 +340,7 @@ def mv(source: str | list[str], target: str) -> None:
                 raise FSError(f"Destination path '{real_dst}' already exists")
         try:
             os.rename(src, real_dst)
-        except OSError:
+        except OSError as err:
             if os.path.islink(src):
                 linkto = os.readlink(src)
                 os.symlink(linkto, real_dst)
@@ -351,7 +349,7 @@ def mv(source: str | list[str], target: str) -> None:
                 if destinsrc(src, dst):
                     raise FSError(
                         "Cannot move a directory '%s' into itself '%s'." % (src, dst)
-                    )
+                    ) from err
                 shutil.copytree(src, real_dst, symlinks=True)
                 rm(src, recursive=True)
             else:
@@ -387,7 +385,7 @@ def mv(source: str | list[str], target: str) -> None:
                 move_file(f, f_dest)
     except Exception as e:
         logger.error(e)
-        raise FSError(origin="mv", message=str(e)).with_traceback(sys.exc_info()[2])
+        raise FSError(origin="mv", message=str(e)) from e
 
 
 def rm(path: str | list[str], recursive: bool = False, glob: bool = True) -> None:
@@ -486,7 +484,7 @@ def rm(path: str | list[str], recursive: bool = False, glob: bool = True) -> Non
             logger.error(e)
             raise FSError(
                 origin="rm", message=f"error occurred while removing {f}"
-            ).with_traceback(sys.exc_info()[2])
+            ) from e
 
 
 def splitall(path: str) -> tuple[str, ...]:

--- a/src/e3/job/scheduler.py
+++ b/src/e3/job/scheduler.py
@@ -204,7 +204,7 @@ class Scheduler:
                 p.interrupt()
                 self.safe_collect(p)
                 p.on_finish(self)
-            raise KeyboardInterrupt
+            raise
         self.stop_time = datetime.now()
 
     def push(self, job: Job) -> None:

--- a/src/e3/os/fs.py
+++ b/src/e3/os/fs.py
@@ -42,9 +42,7 @@ def cd(path: str) -> None:
         os.chdir(path)
     except Exception as e:
         logger.error(e, exc_info=True)
-        raise OSFSError(origin="cd", message=f"can't chdir to {path}\n").with_traceback(
-            sys.exc_info()[2]
-        )
+        raise OSFSError(origin="cd", message=f"can't chdir to {path}\n") from e
 
 
 def chmod(mode: str, filename: str) -> int:

--- a/src/e3/os/process.py
+++ b/src/e3/os/process.py
@@ -700,8 +700,8 @@ def wait_for_processes(process_list: list[Run], timeout: float) -> Optional[int]
                     # Process is exiting so finalize it by calling wait
                     process_list[idx].wait()
                     return idx
-            except OSError:
-                raise WaitError
+            except OSError as err:
+                raise WaitError from err
 
     else:  # windows: no cover
         import select

--- a/src/e3/os/windows/fs.py
+++ b/src/e3/os/windows/fs.py
@@ -580,7 +580,7 @@ class NTFile:
                                 message=f"dir {self.path} is not empty "
                                 f"(file '{self.is_dir_empty_last_seen_file}' found)",
                                 origin="NTFile.unlink",
-                            )
+                            ) from e
                     elif e.status == Status.CANNOT_DELETE:  # defensive code
                         # At this stage we are sure that the file is not
                         # read_only but it seems that we can get this error

--- a/src/e3/os/windows/native_api.py
+++ b/src/e3/os/windows/native_api.py
@@ -177,7 +177,7 @@ class FileTime(Structure):
             return datetime.fromtimestamp(self.filetime // 10000000 - 11644473600)
         except ValueError as err:  # defensive code
             # Add some information to ease debugging
-            raise ValueError(f"filetime '{self.filetime}' failed with {err}")
+            raise ValueError(f"filetime '{self.filetime}' failed with {err}") from err
 
     def __str__(self) -> str:
         try:

--- a/src/e3/vcs/svn.py
+++ b/src/e3/vcs/svn.py
@@ -199,9 +199,9 @@ class SVNRepository:
         """
         try:
             return self.get_info("Last Changed Rev")
-        except Exception:
+        except Exception as err:
             logger.exception("Cannot fetch last changed rev")
-            raise SVNError("Cannot fetch last changed rev", "svn_cmd")
+            raise SVNError("Cannot fetch last changed rev", "svn_cmd") from err
 
     def update(
         self,

--- a/src/e3/yaml.py
+++ b/src/e3/yaml.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import os
 import re
-import sys
 from collections import OrderedDict
 from typing import TYPE_CHECKING
 
@@ -94,7 +93,7 @@ class OrderedDictYAMLLoader(Loader):
                     context_mark=node.start_mark,
                     problem=f"found unacceptable key ({exc})",
                     problem_mark=key_node.start_mark,
-                )
+                ) from exc
             value = self.construct_object(value_node, deep=deep)
             if key in mapping:
                 raise yaml.constructor.ConstructorError(
@@ -306,14 +305,12 @@ def load_with_config(filename: str | list[str], config: dict) -> Any:
             e3.log.debug("load config file: %s", f)
             conf_data = load_ordered(f)
             result = parser.parse(conf_data)
-        except OSError:
-            raise YamlError(f"cannot read: {f}", "load_with_config").with_traceback(
-                sys.exc_info()[2]
-            )
-        except (yaml.parser.ParserError, yaml.constructor.ConstructorError) as e:
+        except OSError as err:
+            raise YamlError(f"cannot read: {f}", "load_with_config") from err
+        except (yaml.parser.ParserError, yaml.constructor.ConstructorError) as err:
             raise YamlError(
-                f"{f} is an invalid yaml file: {e}", "load_with_config"
-            ).with_traceback(sys.exc_info()[2])
+                f"{f} is an invalid yaml file: {err}", "load_with_config"
+            ) from err
 
     return result
 


### PR DESCRIPTION
Given that e3-core is not compatible with Python 2 anymore, the
code can benefit from the Python3 exception chaining syntax:

    raise Error(...) from err