### PR TITLE
Fix event handler configuration through env variables

### DIFF
--- a/src/e3/event/__init__.py
+++ b/src/e3/event/__init__.py
@@ -338,7 +338,10 @@ class EventManager:
         for handler_name, handler in list(self.handlers.items()):
             config_str = handler.encode_config()
             assert "|" not in config_str
-            result.append(f"{handler_name}={config_str}")
+            if config_str:
+                result.append(f"{handler_name}={config_str}")
+            else:
+                result.append(handler_name)
         os.environ[var_name] = "|".join(result)
 
 


### PR DESCRIPTION
This commit removes unnecessary '=' at the end of string
configuration.

TN:UA12-039