### PR TITLE
Fix crash using Run.err if error=STDOUT

### DIFF
--- a/src/e3/os/process.py
+++ b/src/e3/os/process.py
@@ -343,7 +343,7 @@ class Run:
 
         self.status: Optional[int] = None
         self.raw_out = b""
-        self.raw_err = b""
+        self.raw_err: Optional[bytes] = b""
         self.cmds = []
 
         if env is not None:
@@ -474,13 +474,15 @@ class Run:
         return bytes_as_str(self.raw_out)
 
     @property
-    def err(self) -> str:
+    def err(self) -> Optional[str]:
         """Process error as string.
 
         Attempt is done to decode as utf-8 the output. If the output is not in
         utf-8 a string representation will be returned
         (see e3.text.bytes_as_str).
         """
+        if self.raw_err is None:
+            return None
         return bytes_as_str(self.raw_err)
 
     def command_line_image(self) -> str:

--- a/tests/tests_e3/os/process/main_test.py
+++ b/tests/tests_e3/os/process/main_test.py
@@ -9,6 +9,8 @@ import e3.os.process
 
 import pytest
 
+from subprocess import STDOUT
+
 try:
     import psutil
 except ImportError:
@@ -408,3 +410,8 @@ def test_shell_override():
         fd.write("#!/bin/bash\nimport sys; print(sys.executable)\n")
     p = e3.os.process.Run([test_file_path], parse_shebang=True)
     assert p.out.strip() == sys.executable
+
+
+def test_error_to_stdout():
+    p = e3.os.process.Run(["echo", "1"], error=STDOUT)
+    assert p.err is None


### PR DESCRIPTION
Run.raw_err can be None when stderr is redirected to stdout. Handle
that case properly and adjust the type annotations

TN: UA20-055