### PR TITLE
Use distro instead of ld

### DIFF
--- a/src/e3/os/platform.py
+++ b/src/e3/os/platform.py
@@ -78,12 +78,12 @@ class SystemInfo:
 
         # Fetch linux distribution info on linux OS
         if cls.uname.system == "Linux":  # linux-only
-            import ld
+            import distro
 
             cls.ld_info = {
-                "name": ld.name(),
-                "major_version": ld.major_version(),
-                "version": ld.version(),
+                "name": distro.name(),
+                "major_version": distro.major_version(),
+                "version": distro.version(),
             }
 
         # Fetch core numbers. Note that the methods does not work


### PR DESCRIPTION
It seems to me that distro is the new name of ld
ld stopped in 2016 while distro has been recently updated. Latest release on july
and ld is not present in some linux distro