### PR TITLE
Fix typo in quickstart guide

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -37,7 +37,7 @@ Running:
 
 .. code-block:: python
 
-    Run(['python'], output=2)
+    Run(['python'], timeout=2)
 
 will exit the :program:`python` program after 2 seconds whereas
 


### PR DESCRIPTION
I grepped for other instances of `output=[0-9]`, but nothing jumped at me. Let me know if there are other things I should look at.