### PR TITLE
Add pytest-socket to test packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     "stevedore>1.20.0",
 ]
 
-extras_require = {"config": ["tomlkit", "typeguard"]}
+extras_require = {"config": ["tomlkit", "typeguard"], "test": ["pytest-socket"]}
 
 for p in ("darwin", "linux", "linux2", "win32"):
     platform_string = ":sys_platform=='%s'" % p


### PR DESCRIPTION
pytest-socket is needed to run tests on e3-core; however, it should only
be added via the "test" option, as it is not a core dependency.

TN: V217-040