### PR TITLE
Insert 2022 in Windows Server OS version

### DIFF
--- a/src/e3/os/platform.py
+++ b/src/e3/os/platform.py
@@ -270,6 +270,11 @@ class SystemInfo:
                             version = "2019"
                     else:
                         version = "10"
+                elif effective_version == 11.0:
+                    if is_server:
+                        version = "2022"
+                    else:
+                        version = "11"
 
         cls._os_version = (version, kernel_version)
         return version, kernel_version


### PR DESCRIPTION
Insertion of Windows Server 2022 and Windows 11 inside OS versions of
e3.os.platforms.

TN: V202-008