### PR TITLE
Fix build number for Windows Server 2022

### DIFF
--- a/src/e3/os/platform.py
+++ b/src/e3/os/platform.py
@@ -266,15 +266,12 @@ class SystemInfo:
                     if is_server:
                         if build_number < 17763:
                             version = "2016"
-                        else:
+                        elif build_number < 20348:
                             version = "2019"
+                        else:
+                            version = "2022"
                     else:
                         version = "10"
-                elif effective_version == 11.0:
-                    if is_server:
-                        version = "2022"
-                    else:
-                        version = "11"
 
         cls._os_version = (version, kernel_version)
         return version, kernel_version


### PR DESCRIPTION
Windows Server 2022 and Windows 11 are, in fact, continuous to Windows 10 versioning.
See the following link for more details:
https://docs.microsoft.com/en-us/windows-server/get-started/windows-server-release-info

TN: V202-008