### PR TITLE
Use `exists` to test for `.git` in checkout.py

### DIFF
--- a/src/e3/anod/checkout.py
+++ b/src/e3/anod/checkout.py
@@ -148,7 +148,7 @@ class CheckoutManager:
             if p.status != 0:
                 raise e3.error.E3Error("rsync failed")
         else:
-            if os.path.isdir(os.path.join(url, ".git")):
+            if os.path.exists(os.path.join(url, ".git")):
                 # It seems that this is a git repository. Get the list of files to
                 # ignore
                 try:


### PR DESCRIPTION
Fixes #522 

Instead of using `isdir` use `exists` to test for `.git` as a means of
determining that the external to update is a git repository.