### PR TITLE
Add an exception in e3.diff.patch function

### DIFF
--- a/src/e3/diff.py
+++ b/src/e3/diff.py
@@ -268,7 +268,8 @@ def patch(
         files_to_patch = process_git_patch()
     else:
         files_to_patch = process_regular_patch()
-    if files_to_patch:
-        apply_patch(filtered_patch)
-    else:
-        logger.debug("All %s content has been discarded", patch_file)
+
+    if files_to_patch == 0:
+        raise DiffError(origin="patch", message="No file to patch")
+
+    apply_patch(filtered_patch)

--- a/tests/tests_e3/diff/main_test.py
+++ b/tests/tests_e3/diff/main_test.py
@@ -58,9 +58,8 @@ def test_patch_ignore_all(caplog):
 
     e3.fs.cp(file_to_patch, current_dir)
     e3.fs.cp(file_patch2, current_dir)
-    e3.diff.patch("patch2.txt", current_dir, discarded_files=lambda x: True)
-
-    assert "All patch2.txt content has been discarded" in caplog.text
+    with pytest.raises(e3.diff.DiffError):
+        e3.diff.patch("patch2.txt", current_dir, discarded_files=lambda x: True)
 
 
 def test_discarded():
@@ -145,7 +144,9 @@ def test_patch_git_format_ignore():
     assert "That's nice it's working !" in content
 
     e3.fs.cp(file_to_patch, cwd)
-    e3.diff.patch("git_diff.patch", cwd, discarded_files=["git_file.txt"])
+    with pytest.raises(e3.diff.DiffError):
+        e3.diff.patch("git_diff.patch", cwd, discarded_files=["git_file.txt"])
+
     with open(os.path.join(cwd, "git_file.txt")) as fd:
         content = fd.read()
     assert "That's nice it's working !" not in content
@@ -190,7 +191,9 @@ def test_patch_git_with_headers():
 
     e3.fs.rm("file1")
     e3.fs.rm("file2")
-    e3.diff.patch("git_patch_with_header", cwd, discarded_files=["file*"])
+    with pytest.raises(e3.diff.DiffError):
+        e3.diff.patch("git_patch_with_header", cwd, discarded_files=["file*"])
+
     assert not os.path.isfile("file1")
     assert not os.path.isfile("file2")
 


### PR DESCRIPTION
Change the e3.diff.patch function to raise
an exception if there is no file to patch.

TN: S909-004