### PR TITLE
Disable test_svn_checkout temporarly

### DIFF
--- a/tests/tests_e3/anod/checkout_test.py
+++ b/tests/tests_e3/anod/checkout_test.py
@@ -42,6 +42,7 @@ class TestCheckout:
     repo_data = os.path.join(os.path.dirname(__file__), "vcs_data")
     repo_data2 = os.path.join(os.path.dirname(__file__), "vcs_data2")
 
+    @pytest.mark.skip(reason="Test is failing on some platforms. Disable until fixed.")
     @pytest.mark.parametrize("compute_changelog", [True, False])
     @pytest.mark.parametrize("e3_feature", ["", "git_shallow_fetch"])
     def test_svn_checkout(self, svn, compute_changelog, e3_feature):


### PR DESCRIPTION
test_svn_checkout is failing due to issues running svn on win2016 platforms. Skip it for now.