### PR TITLE
Replace safety by pip-audit

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,10 +42,10 @@ commands=
 # environment variable. Don't check for that.
 deps =
       bandit
-      safety
+      pip-audit
 commands =
       bandit -r e3 -ll -ii -s B102,B108,B301,B303,B506
-      safety check --full-report
+      pip-audit --desc on --skip-editable
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
pip-audit outputs up-to-date vulnerability which is not the case for safety when using the free version

Fix #548