### PR TITLE
Move test dependencies in extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ install_requires = [
     "requests_toolbelt",
     "tqdm",
     "stevedore>1.20.0",
+    "setuptools",
 ]
 
 extras_require = {
@@ -18,7 +19,7 @@ extras_require = {
         # There are some backward incompatible checks in typeguard 3.x
         "typeguard<3.0.0",
     ],
-    "test": ["pytest-socket"],
+    "test": ["mock", "pytest-html", "pytest-socket", "ansi2html", "httpretty"],
 }
 
 for p in ("darwin", "linux", "linux2", "win32"):

--- a/tox.ini
+++ b/tox.ini
@@ -3,24 +3,17 @@ envlist = py39-cov-xdist
 
 [testenv]
 deps =
-     pytest
-     pytest-html
-     ansi2html
      xdist: pytest-xdist[psutil]
-     pytest-socket
      # ??? needs to be added as a dep of e3-core
      requests-cache
-     mock
-     # httpretty version 1.0.0 seems to be buggy, crash at install time
-     httpretty != 1.0.0
-     importlib_metadata < 5.0.0
-     pyyaml
      cov: pytest-cov
      cov: coverage
      codecov: codecov
 
 passenv = CI,GITHUB_*,CODECOV_*
-extras = config
+extras =
+      config
+      test
 
 # Run testsuite with coverage when '-cov' is in the env name
 commands=
@@ -45,6 +38,9 @@ commands=
 deps =
       bandit
       pip-audit
+      setuptools >= 65.5.1
+      wheel >= 0.38.1
+extras = config
 commands =
       bandit -r e3 -ll -ii -s B102,B108,B301,B303,B506
       pip-audit --desc on --skip-editable


### PR DESCRIPTION
This avoid having to list them in tox.ini and allows us reusing the test dependencies in other workflows.

Also freeze typeguard to versions 2.x given that there are backward incompatible change in typeguard 3.x (for check_type)