### PR TITLE
Add missing dataclass decorator

### DIFF
--- a/src/e3/spdx.py
+++ b/src/e3/spdx.py
@@ -114,6 +114,7 @@ class SPDXEntryBool(SPDXEntry):
         return {self.json_entry_key: self.value}
 
 
+@dataclass
 class SPDXSection:
     """Describe a SPDX section."""
 


### PR DESCRIPTION
This is needed for mypy, otherwise the use of fields() is flagged.