### PR TITLE
Fix mypy issue (unused type: ignore)

### DIFF
--- a/src/e3/archive.py
+++ b/src/e3/archive.py
@@ -50,12 +50,12 @@ if sys.platform == "win32":
 
     class E3ZipInfo(zipfile.ZipInfo):
         @classmethod
-        def from_file(cls, *args, **kwargs):  # type: ignore
+        def from_file(cls, *args, **kwargs):
             result = super().from_file(*args, **kwargs)
             result.external_attr = (0o555 << 16) | result.external_attr
             return result
 
-    zipfile.ZipInfo = E3ZipInfo  # type: ignore
+    zipfile.ZipInfo = E3ZipInfo
 
 
 class E3ZipFile(zipfile.ZipFile):

--- a/src/e3/config.py
+++ b/src/e3/config.py
@@ -69,7 +69,7 @@ class ConfigSection:
                 else:
                     kwargs[k] = v
 
-        return cls(**kwargs)  # type: ignore
+        return cls(**kwargs)
 
 
 class Config:

--- a/src/e3/log.py
+++ b/src/e3/log.py
@@ -325,7 +325,7 @@ def add_log_handlers(
     else:
         fmt = logging.Formatter(log_format, datefmt)
 
-    fmt.converter = time.gmtime  # type: ignore
+    fmt.converter = time.gmtime
     handler.setFormatter(fmt)
 
     handler.setLevel(level)

--- a/src/e3/os/fs.py
+++ b/src/e3/os/fs.py
@@ -173,13 +173,13 @@ def df(path: str, full: bool = False) -> int | tuple:
             ((1, "path"), (2, "freeuserspace"), (2, "totalspace"), (2, "freespace")),
         )
 
-        def GetDiskFreeSpaceEx_errcheck(result, func, args):  # type: ignore
+        def GetDiskFreeSpaceEx_errcheck(result, func, args):
             del func
             if not result:  # defensive code
                 raise ctypes.WinError()
             return (args[1].value, args[2].value, args[3].value)
 
-        GetDiskFreeSpaceEx.errcheck = GetDiskFreeSpaceEx_errcheck  # type: ignore
+        GetDiskFreeSpaceEx.errcheck = GetDiskFreeSpaceEx_errcheck
         _, total, free = GetDiskFreeSpaceEx(c_path)
         used = total - free
     else:  # windows: no cover

--- a/src/e3/sys.py
+++ b/src/e3/sys.py
@@ -333,7 +333,7 @@ def is_console() -> bool:
     # First check using isatty call. On Windows isatty will return True only
     # if in a Win32 console (for example cygwin or msys ptys are not win32
     # consoles).
-    is_tty = os.isatty(stdin_fd)  # type: ignore
+    is_tty = os.isatty(stdin_fd)
     if is_tty:
         return True
 
@@ -341,7 +341,7 @@ def is_console() -> bool:
         from msvcrt import get_osfhandle
         from e3.os.windows.object import object_name
 
-        stdin_name = object_name(get_osfhandle(stdin_fd))  # type: ignore
+        stdin_name = object_name(get_osfhandle(stdin_fd))
         if re.match(r"\\Device\\NamedPipe\\(cygwin|msys).*-pty.*$", stdin_name):
             return True
         else:


### PR DESCRIPTION
During the mypy bump of e3-distrib, some unused type: ignore was detected by mypy

it/org/software-supply-chain/issues#2