### PR TITLE
Set endianness information on aarch64-linux platforms

### DIFF
--- a/src/e3/platform_db/knowledge_base.py
+++ b/src/e3/platform_db/knowledge_base.py
@@ -80,7 +80,12 @@ PLATFORM_INFO: PlatformDBEntry = {
     "aarch64-darwin": {"cpu": "aarch64", "os": "darwin", "is_hie": False},
     "aarch64-elf": {"cpu": "aarch64", "os": "none", "is_hie": True},
     "aarch64-ios": {"cpu": "aarch64", "os": "ios", "is_hie": False},
-    "aarch64-linux": {"cpu": "aarch64", "os": "linux", "is_hie": False},
+    "aarch64-linux": {
+        "cpu": "aarch64",
+        "os": "linux",
+        "is_hie": False,
+        "endian": "little",
+    },
     "arm-android": {"cpu": "arm", "os": "android", "is_hie": False},
     "arm-elf": {"cpu": "arm", "os": "none", "is_hie": True},
     "arm-ios": {"cpu": "arm", "os": "ios", "is_hie": False},


### PR DESCRIPTION
The following program shows that the endianness is not set when the platform is aarch64-linux:

    | from e3.env import Env
    | Env().set_target("aarch64-linux")
    | print(Env().target.cpu.endian)

Currently, the program currently prints:

    unknown

This fix allows the endianness to be set to the correct value, which is "little".

This change was tested by running this repository's testsuite as well as AdaCore internal e3-adacore testsuite.