### PR TITLE
Improve download_file API with a fileobj parameter

### DIFF
--- a/tests/tests_e3/net/http_test.py
+++ b/tests/tests_e3/net/http_test.py
@@ -3,6 +3,7 @@ import logging
 import os
 import threading
 import time
+from io import BytesIO
 
 import requests_toolbelt.multipart
 from e3.net.http import HTTPSession, HTTPError
@@ -142,6 +143,16 @@ class TestHTTP:
                 with open(result, "rb") as fd:
                     content = fd.read()
                 assert content == b"Dummy!"
+                assert os.path.basename(result) == "dummy.txt"
+
+        run_server(ContentDispoHandler, func)
+
+    def test_content_dispo_fileobj(self, socket_enabled):
+        def func(server, base_url):
+            with HTTPSession() as session:
+                fo = BytesIO()
+                result = session.download_file(base_url + "dummy", fileobj=fo)
+                assert fo.getvalue() == b"Dummy!"
                 assert os.path.basename(result) == "dummy.txt"
 
         run_server(ContentDispoHandler, func)


### PR DESCRIPTION
HTTPSession.download_file provides an easy way to download a file from an URL and save it to disk. However it may be sometimes interesting to keep the file in memory, if you don't want to, or don't need to save it temporarily to disk.

This change makes download_file more look like the API of tarfile.open, that allows you to either pass the name of a file, or a file object to read from.

Here the typing of the file object is done with a Protocol, which is the convention from typeshed (for the record
https://github.com/python/typing/discussions/829)