### PR TITLE
Name generator fix test only

### DIFF
--- a/src/e3/anod/qualifiers_manager.py
+++ b/src/e3/anod/qualifiers_manager.py
@@ -783,9 +783,9 @@ class QualifiersManager:
 
         return "\n".join(helper_list)
 
-    def __getitem__(self, key: str) -> str:
+    def __getitem__(self, key: str) -> str | bool:
         """Return the parsed value of the requested qualifier.
 
         :return: The qualifier value after the parsing.
         """
-        return str(self.__get_parsed_qualifiers()[key])
+        return self.__get_parsed_qualifiers()[key]

--- a/src/e3/anod/qualifiers_manager.py
+++ b/src/e3/anod/qualifiers_manager.py
@@ -736,7 +736,7 @@ class QualifiersManager:
 
         # Compute hash_suffix
         if self.hash_pool:
-            hash_suffix = f"_{sha1(self.hash_pool.encode()).hexdigest()}"
+            hash_suffix = f"_{sha1(self.hash_pool.encode()).hexdigest()[:8]}"
 
         return self.base_name + qualifier_suffix + hash_suffix + kind_suffix
 

--- a/src/e3/anod/qualifiers_manager.py
+++ b/src/e3/anod/qualifiers_manager.py
@@ -710,7 +710,7 @@ class QualifiersManager:
 
         component_name = self.component
 
-        if component_name is not None:
+        if component_name is not None and self.anod_instance.kind != "test":
             # A component name has been defined and must be used.
             return component_name
 

--- a/src/e3/anod/spec.py
+++ b/src/e3/anod/spec.py
@@ -406,7 +406,7 @@ class Anod:
         elif key.isupper():
             return getattr(self.build_space, key.lower(), None)
 
-    def get_qualifier(self, qualifier_name: str) -> str | None:
+    def get_qualifier(self, qualifier_name: str) -> str | bool | None:
         """Return a qualifier value.
 
         Requires that qualifiers_manager attribute has been initialized and its parse
@@ -420,7 +420,7 @@ class Anod:
             assert self.qualifiers_manager is not None
             return self.qualifiers_manager[qualifier_name]
         else:
-            return None
+            return self.parsed_qualifier.get(qualifier_name, None)
 
     @classmethod
     def primitive(

--- a/src/e3/anod/spec.py
+++ b/src/e3/anod/spec.py
@@ -248,8 +248,6 @@ class Anod:
             self.qualifiers_manager = QualifiersManager(self)
             self.declare_qualifiers_and_components(self.qualifiers_manager)
             self.qualifiers_manager.parse(self.parsed_qualifier)
-        else:
-            self.qualifier_manager = None
 
         # UID of the spec instance
         self.uid = ".".join(

--- a/tests/tests_e3/anod/test_qualifier_manager.py
+++ b/tests/tests_e3/anod/test_qualifier_manager.py
@@ -406,28 +406,19 @@ def test_qualifiers_manager():
     anod_no_component_1 = AnodNoComponent(
         "debug,version=1.2,path=/some/path,path_bis=/other/path", kind="build"
     )
-    assert (
-        anod_no_component_1.build_space_name
-        == "my_spec_debug_1.2_ca656cbada5f82b1063b10f1e1adaeb11c98e6fe"
-    )
+    assert anod_no_component_1.build_space_name == "my_spec_debug_1.2_ca656cba"
     assert anod_no_component_1.component is None
 
     anod_no_component_2 = AnodNoComponent(
         "version=1.2,path=/some/path,path_bis=/other/path", kind="build"
     )
-    assert (
-        anod_no_component_2.build_space_name
-        == "my_spec_1.2_ca656cbada5f82b1063b10f1e1adaeb11c98e6fe"
-    )
+    assert anod_no_component_2.build_space_name == "my_spec_1.2_ca656cba"
     assert anod_no_component_2.component is None
 
     anod_no_component_3 = AnodNoComponent(
         "debug,version=1.2,path=/different/path,path_bis=/path", kind="build"
     )
-    assert (
-        anod_no_component_3.build_space_name
-        == "my_spec_debug_1.2_7a7d1e2193d81f68693fe880de86a1c54bfcbb2c"
-    )
+    assert anod_no_component_3.build_space_name == "my_spec_debug_1.2_7a7d1e21"
     assert anod_no_component_3.component is None
 
     class AnodComponent(Anod):

--- a/tests/tests_e3/anod/test_qualifier_manager.py
+++ b/tests/tests_e3/anod/test_qualifier_manager.py
@@ -32,12 +32,12 @@ def test_anod_name_generator():
     simple = Simple("", kind="build")
     assert simple.build_space_name == "simple"
     assert simple.component is None
-    assert simple.get_qualifier("debug") == "False"
+    assert not simple.get_qualifier("debug")
 
     simple_debug = Simple("debug", kind="build")
     assert simple_debug.build_space_name == "simple_debug"
     assert simple_debug.component is None
-    assert simple_debug.get_qualifier("debug") == "True"
+    assert simple_debug.get_qualifier("debug")
 
     # Disable the name generator
     class Base(Anod):
@@ -45,6 +45,9 @@ def test_anod_name_generator():
 
     base = Base("", kind="build")
     assert base.get_qualifier("debug") is None
+
+    base = Base("debug=bar", kind="build")
+    assert base.get_qualifier("debug") == "bar"
 
 
 def test_qualifiers_manager_errors():


### PR DESCRIPTION
Resolve #599.

Fix the test_only qualifier handling in QualfiiersManager.
Reduce the size of the final hash to 8 characters as 40 was to much.
Make the get_qualifier method of Anod return a boolean for tag qualfiiers.
Always use the generated build space name in test mode.