### PR TITLE
Amend anod primitive signature

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,14 @@ extras_require = {
         # There are some backward incompatible checks in typeguard 3.x
         "typeguard<3.0.0",
     ],
-    "test": ["mock", "pytest-html", "pytest-socket", "ansi2html", "httpretty"],
+    "test": [
+        "mock",
+        "pytest",
+        "pytest-html",
+        "pytest-socket",
+        "ansi2html",
+        "httpretty",
+    ],
 }
 
 for p in ("darwin", "linux", "linux2", "win32"):

--- a/src/e3/anod/spec.py
+++ b/src/e3/anod/spec.py
@@ -131,6 +131,7 @@ def fetch_attr(instance: Any, name: str, default_value: Any) -> Any:
     )
 
 
+# noinspection PyShadowingNames
 class Anod:
     """Anod base class.
 
@@ -244,6 +245,8 @@ class Anod:
 
         # Create the QualifiersManager.
         # Skip if the name generator is disabled.
+        self.qualifier_manager = None
+
         if self.enable_name_generator:
             self.qualifiers_manager = QualifiersManager(self)
             self.declare_qualifiers_and_components(self.qualifiers_manager)
@@ -352,7 +355,7 @@ class Anod:
         list of available file is set by the data_files parameter when
         initializing the spec.
 
-        :param suffix: suffix of the configuration file (default is '')
+        :param suffix: suffix of the configuration file (default is "")
         :param extended: if True then a special yaml parser is used with
             ability to use case statement
         :param selectors: additional selectors for extended mode
@@ -407,8 +410,8 @@ class Anod:
     def get_qualifier(self, qualifier_name: str) -> str | bool | None:
         """Return a qualifier value.
 
-        Requires that qualifiers_manager attribute has been initialized and its parse
-        method called.
+        Requires that qualifiers_manager attribute has been initialized and its
+        parse method called.
 
         :return: The qualifier value. Its a string for key value qualifiers and a bool
             for tag qualifiers.
@@ -449,8 +452,6 @@ class Anod:
         def primitive_dec(f, pre=pre, post=post, version=version):  # type: ignore
             def primitive_func(self, *args, **kwargs):  # type: ignore
                 self.log.debug("%s %s starts", self.name, f.__name__)
-
-                result = False
 
                 # Ensure temporary directory is set to a directory local to
                 # the current sandbox. This avoid mainly to loose track of

--- a/src/e3/anod/spec.py
+++ b/src/e3/anod/spec.py
@@ -159,7 +159,7 @@ class Anod:
     :cvar sandbox: e3.anod.sandbox.SandBox object shared by all Anod instances
     :vartype sandbox: e3.anod.sandbox.SandBox | None
 
-    Some attributes are meant the be overwritten in the specification file:
+    Some attributes are meant to be overwritten in the specification file:
 
     :cvar source_pkg_build: a dictionary associating Anod.SourceBuilder to the
         Anod.Source names
@@ -390,7 +390,7 @@ class Anod:
         __getitem__, e.g. self['PKG_DIR'] to access
         self.build_space.pkg_dir values.
 
-        Also directly access items returned by the ``pre`` callback.
+        Also, directly accesses items returned by the ``pre`` callback.
         """
         if self.__build_space is None:
             return "unknown"
@@ -413,8 +413,8 @@ class Anod:
         Requires that qualifiers_manager attribute has been initialized and its
         parse method called.
 
-        :return: The qualifier value. Its a string for key value qualifiers and a bool
-            for tag qualifiers.
+        :return: The qualifier value. It's a string for key value qualifiers
+            and a bool for tag qualifiers.
             Return None if the name_generator is disabled.
         """
         if self.enable_name_generator:
@@ -454,7 +454,7 @@ class Anod:
                 self.log.debug("%s %s starts", self.name, f.__name__)
 
                 # Ensure temporary directory is set to a directory local to
-                # the current sandbox. This avoid mainly to loose track of
+                # the current sandbox. This mainly avoids losing track of
                 # temporary files that are then accumulating on the
                 # filesystems.
                 # ??? Temporary fix for T409-012 ???

--- a/tests/tests_e3/anod/primitive_test.py
+++ b/tests/tests_e3/anod/primitive_test.py
@@ -1,0 +1,226 @@
+import os
+
+from pathlib import Path
+
+from e3.anod.driver import AnodDriver
+from e3.anod.sandbox import SandBox
+from e3.anod.spec import Anod
+
+
+def test_primitive_with_pre():
+    """Test an Anod primitive with a *pre* parameter of type string."""
+    build_called: str = "build called"
+    setup_called: str = "setup called + "
+
+    class SimpleWithPreStr(Anod):
+        # Define a global string to be updated by both methods.
+        common: str = ""
+
+        @Anod.primitive()
+        def setup(self, *_args) -> None:
+            self.common += setup_called
+
+        @Anod.primitive(pre="setup")
+        def build(self) -> str:
+            self.common += build_called
+            self.log.debug(" build returning {0}".format(self.common))
+            return self.common
+
+    class SimpleWithPreCallable(Anod):
+        # Define a global string to be updated by both methods.
+        common: str = ""
+
+        @Anod.primitive()
+        def setup(self, *_args) -> None:
+            self.common = setup_called
+
+        # noinspection PyTypeChecker
+        @Anod.primitive(pre=setup)
+        def build(self) -> str:
+            self.common += build_called
+            self.log.debug(" build returning {0}".format(self.common))
+            return self.common
+
+    spec_dir = Path(Path(__file__).parent, "data").resolve()
+
+    with_pre_str = SimpleWithPreStr("", "build")
+    with_pre_callable = SimpleWithPreCallable("", "build")
+
+    Anod.sandbox = SandBox(root_dir=os.getcwd())
+    Anod.sandbox.spec_dir = str(spec_dir.resolve())
+    Anod.sandbox.create_dirs()
+
+    AnodDriver(anod_instance=with_pre_str, store=None).activate(Anod.sandbox, None)
+    AnodDriver(anod_instance=with_pre_callable, store=None).activate(Anod.sandbox, None)
+
+    for anod_class in with_pre_str, with_pre_callable:
+        anod_class.build_space.create()
+        anod_class.build()
+        assert anod_class.common == setup_called + build_called
+
+
+def test_primitive_with_post():
+    """Test an Anod primitive with a *post* parameter of any type."""
+    build_called: str = "build called"
+    install_called: str = " + install called"
+
+    class SimpleWithPostStr(Anod):
+        # Define a global string to be updated by both methods.
+        common: str = ""
+
+        @Anod.primitive()
+        def install(self, *_args) -> None:
+            self.common += install_called
+
+        @Anod.primitive(post="install")
+        def build(self) -> str:
+            self.common += build_called
+            self.log.debug(" build returning {0}".format(self.common))
+            return self.common
+
+    class SimpleWithPostCallable(Anod):
+        # Define a global string to be updated by both methods.
+        common: str = ""
+
+        @Anod.primitive()
+        def install(self, *_args) -> None:
+            self.common += install_called
+
+        @Anod.primitive(post=install)
+        def build(self) -> str:
+            self.common += build_called
+            self.log.debug(" build returning {0}".format(self.common))
+            return self.common
+
+    spec_dir = Path(Path(__file__).parent, "data").resolve()
+
+    with_post_str = SimpleWithPostStr("", "build")
+    with_post_callable = SimpleWithPostCallable("", "build")
+
+    Anod.sandbox = SandBox(root_dir=os.getcwd())
+    Anod.sandbox.spec_dir = str(spec_dir.resolve())
+    Anod.sandbox.create_dirs()
+
+    AnodDriver(anod_instance=with_post_str, store=None).activate(Anod.sandbox, None)
+    AnodDriver(anod_instance=with_post_callable, store=None).activate(
+        Anod.sandbox, None
+    )
+
+    for anod_class in with_post_str, with_post_callable:
+        anod_class.build_space.create()
+        anod_class.build()
+        assert anod_class.common == build_called + install_called
+
+
+def test_primitive_with_pre_and_post():
+    """Test an Anod primitive with a *post* parameter of any type."""
+    build_called: str = "build called"
+    install_called: str = " + install called"
+    setup_called: str = "setup called + "
+
+    class SimpleWithPreStrPostStr(Anod):
+        # Define a global string to be updated by both methods.
+        common: str = ""
+
+        @Anod.primitive()
+        def setup(self, *_args) -> None:
+            self.common += setup_called
+
+        @Anod.primitive()
+        def install(self, *_args) -> None:
+            self.common += install_called
+
+        @Anod.primitive(pre="setup", post="install")
+        def build(self) -> str:
+            self.common += build_called
+            self.log.debug(" build returning {0}".format(self.common))
+            return self.common
+
+    class SimpleWithPreCallablePostStr(Anod):
+        # Define a global string to be updated by both methods.
+        common: str = ""
+
+        @Anod.primitive()
+        def setup(self, *_args) -> None:
+            self.common += setup_called
+
+        @Anod.primitive()
+        def install(self, *_args) -> None:
+            self.common += install_called
+
+        # noinspection PyTypeChecker
+        @Anod.primitive(pre=setup, post="install")
+        def build(self) -> str:
+            self.common += build_called
+            self.log.debug(" build returning {0}".format(self.common))
+            return self.common
+
+    class SimpleWithPreCallablePostCallable(Anod):
+        # Define a global string to be updated by both methods.
+        common: str = ""
+
+        @Anod.primitive()
+        def setup(self, *_args) -> None:
+            self.common += setup_called
+
+        @Anod.primitive()
+        def install(self, *_args) -> None:
+            self.common += install_called
+
+        # noinspection PyTypeChecker
+        @Anod.primitive(pre=setup, post=install)
+        def build(self) -> str:
+            self.common += build_called
+            self.log.debug(" build returning {0}".format(self.common))
+            return self.common
+
+    class SimpleWithPreStrPostCallable(Anod):
+        # Define a global string to be updated by both methods.
+        common: str = ""
+
+        @Anod.primitive()
+        def setup(self, *_args) -> None:
+            self.common += setup_called
+
+        @Anod.primitive()
+        def install(self, *_args) -> None:
+            self.common += install_called
+
+        # noinspection PyTypeChecker
+        @Anod.primitive(pre="setup", post=install)
+        def build(self) -> str:
+            self.common += build_called
+            self.log.debug(" build returning {0}".format(self.common))
+            return self.common
+
+    spec_dir = Path(Path(__file__).parent, "data").resolve()
+
+    pre_str_post_str = SimpleWithPreStrPostStr("", "build")
+    pre_callable_post_str = SimpleWithPreCallablePostStr("", "build")
+    pre_callable_post_callable = SimpleWithPreCallablePostCallable("", "build")
+    pre_str_post_callable = SimpleWithPreStrPostCallable("", "build")
+
+    Anod.sandbox = SandBox(root_dir=os.getcwd())
+    Anod.sandbox.spec_dir = str(spec_dir.resolve())
+    Anod.sandbox.create_dirs()
+
+    AnodDriver(anod_instance=pre_str_post_str, store=None).activate(Anod.sandbox, None)
+    AnodDriver(anod_instance=pre_callable_post_str, store=None).activate(
+        Anod.sandbox, None
+    )
+    AnodDriver(anod_instance=pre_callable_post_callable, store=None).activate(
+        Anod.sandbox, None
+    )
+    AnodDriver(anod_instance=pre_str_post_callable, store=None).activate(
+        Anod.sandbox, None
+    )
+
+    for anod_class in (
+        pre_str_post_str,
+        pre_callable_post_str,
+        pre_callable_post_callable,
+        pre_str_post_callable,
+    ):
+        anod_class.build_space.create()
+        anod_class.build()
+        assert anod_class.common == setup_called + build_called + install_called


### PR DESCRIPTION
Three commits here.
The first is for linter warning removal.
Second is for english typos.
Last but not least is the real work.

As the `post` parameter of the primitives were not called, I added calls to the post function.
Hope this does not break anything ...