### PR TITLE
Add e3.anod.spec.Anod.deps_source_list

### DIFF
--- a/src/e3/anod/context.py
+++ b/src/e3/anod/context.py
@@ -32,7 +32,7 @@ from e3.env import BaseEnv
 from e3.error import E3Error
 
 if TYPE_CHECKING:
-    from typing import cast, NoReturn, Optional, Tuple
+    from typing import cast, NoReturn, Optional
     from collections.abc import Callable
     from e3.anod.action import Action
     from e3.anod.package import SourceBuilder
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
     from e3.mypy import assert_never
 
     # spec name, build env, target env, host env, qualifier, kind, source name
-    CacheKeyType = Tuple[
+    CacheKeyType = tuple[
         str, Platform, Platform, Platform, Optional[str], Optional[str], Optional[str]
     ]
     ResolverType = Callable[[Action, Decision], bool]
@@ -439,7 +439,16 @@ class AnodContext:
                         spec_instance.name, dep.local_name
                     ),
                 )
-            spec_instance.deps[dep.local_name] = dep_instance
+            if dep.kind != "source":
+                spec_instance.deps[dep.local_name] = dep_instance
+            else:
+                srcbuild_list = dep_instance.source_pkg_build
+                if not srcbuild_list:
+                    spec_instance.deps_source_list[dep.local_name] = set()
+                else:
+                    spec_instance.deps_source_list[dep.local_name] = {
+                        srcbuild.name for srcbuild in srcbuild_list
+                    }
 
         # Initialize a spec instance
         spec = self.load(
@@ -669,7 +678,7 @@ class AnodContext:
                     add_dep(spec_instance=spec, dep=e, dep_instance=child_instance)
                     self.dependencies[spec.uid][e.local_name] = (
                         e,
-                        spec.deps[e.local_name],
+                        child_instance,
                     )
 
                     continue

--- a/src/e3/anod/driver.py
+++ b/src/e3/anod/driver.py
@@ -61,7 +61,17 @@ class AnodDriver:
                     kind=e.kind,
                     env=e.env(self.anod_instance, BaseEnv.from_env()),
                 )
-                self.anod_instance.deps[e.local_name] = dep_instance
+                if e.kind != "source":
+                    self.anod_instance.deps[e.local_name] = dep_instance
+                else:
+                    srcbuild_list = dep_instance.source_pkg_build
+                    if not srcbuild_list:
+                        dep_instance.deps_source_list[e.local_name] = set()
+                    else:
+                        dep_instance.deps_source_list[e.local_name] = {
+                            srcbuild.name for srcbuild in srcbuild_list
+                        }
+
         e3.log.debug("activating spec %s", self.anod_instance.uid)
 
     def call(self, action: str) -> Any:

--- a/src/e3/anod/spec.py
+++ b/src/e3/anod/spec.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
         Literal,
         Union,
     )
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Sequence, Iterable
     from e3.anod.buildspace import BuildSpace
     from e3.anod.sandbox import SandBox
     from e3.env import BaseEnv
@@ -212,6 +212,7 @@ class Anod:
         :raise: SpecError
         """
         self.deps: dict[str, Anod] = {}
+        self.deps_source_list: dict[str, Iterable[str]] = {}
 
         self.kind = kind
         self.jobs = jobs

--- a/tests/tests_e3/anod/context_test.py
+++ b/tests/tests_e3/anod/context_test.py
@@ -498,8 +498,12 @@ class TestContext:
                 assert ctag["plan_line"] == "plan.txt:4"
 
                 # Also verify that the instance deps is properly loaded
-                assert set(action.anod_instance.deps.keys()) == {"spec1"}
-                assert action.anod_instance.deps["spec1"].__class__.__name__ == "Spec1"
+                assert not set(action.anod_instance.deps.keys())
+                # Also verify that the instance source list is properly loaded
+                assert set(action.anod_instance.deps_source_list.keys()) == {"spec1"}
+                assert set(action.anod_instance.deps_source_list["spec1"]) == {
+                    "spec1-src"
+                }
 
         # Also test that we are still able to extract the values
         # after having scheduled the action graph.
@@ -522,11 +526,14 @@ class TestContext:
                 assert sched_dag.get_tag(uid)
 
                 # Also verify that the instance deps is properly loaded
-                assert set(action.anod_instance.deps.keys()) == {"spec1", "spec11"}
+                assert set(action.anod_instance.deps.keys()) == {"spec11"}
+                assert set(action.anod_instance.deps_source_list.keys()) == {"spec1"}
                 assert (
                     action.anod_instance.deps["spec11"].__class__.__name__ == "Spec11"
                 )
-                assert action.anod_instance.deps["spec1"].__class__.__name__ == "Spec1"
+                assert set(action.anod_instance.deps_source_list["spec1"]) == {
+                    "spec1-src"
+                }
 
             elif uid.endswith("spec3.build"):
                 assert sched_dag.get_tag(uid)


### PR DESCRIPTION
e3.anod.spec.Anod.deps_source_list contain the dependencies source list (any e3.anod.deps.Dependency that require 'source_pkg')

e3.anod.spec.Anod.deps will not reference anymore the source_pkg dependencies.