### PR TITLE
Make the qualifiers manager errors clearer

### DIFF
--- a/src/e3/anod/qualifiers_manager.py
+++ b/src/e3/anod/qualifiers_manager.py
@@ -743,7 +743,7 @@ class QualifiersManager:
     def __error(self, msg: str) -> None:
         """Raise an error and print the helper."""
         print(self.__get_helper())
-        raise AnodError(msg)
+        raise AnodError(self.anod_instance.name + ": " + msg)
 
     def __get_helper(self) -> str:
         """Return an helper for the current state of Qualifiers.


### PR DESCRIPTION
Add the name of the spec in the errors messages to help finding out where the errors come from.