### PR TITLE
Do not use the name generator in source mode

### DIFF
--- a/src/e3/anod/spec.py
+++ b/src/e3/anod/spec.py
@@ -244,7 +244,7 @@ class Anod:
 
         # Create the QualifiersManager.
         # Skip if the name generator is disabled.
-        if self.enable_name_generator:
+        if self.enable_name_generator and self.kind != "source":
             self.qualifiers_manager = QualifiersManager(self)
             self.declare_qualifiers_and_components(self.qualifiers_manager)
             self.qualifiers_manager.parse(self.parsed_qualifier)
@@ -322,7 +322,7 @@ class Anod:
             build_space name otherwise.
         :rtype: str | None
         """
-        if self.enable_name_generator:
+        if self.enable_name_generator and self.kind != "source":
             return self.qualifiers_manager.build_space_name
         else:
             return self.name

--- a/tests/tests_e3/anod/test_qualifier_manager.py
+++ b/tests/tests_e3/anod/test_qualifier_manager.py
@@ -417,3 +417,13 @@ def test_qualifiers_manager():
     qualifiers_manager = QualifiersManager(Anod("", kind="build"))
     qualifiers_manager.parse({})
     qualifiers_manager.parse({})
+
+
+def test_qualifiers_with_source_primitive():
+    class SimpleAnod(Anod):
+        enable_name_generator = True
+        base_name = "simple"
+        name = "simple_anod"
+
+    simple_anod = SimpleAnod(kind="source", qualifier="")
+    assert simple_anod.build_space_name == "simple_anod"


### PR DESCRIPTION
The qualifiers are always ignored by source packaging so it is useless.