### PR TITLE
Review implementation of qualifier declarations

### DIFF
--- a/src/e3/anod/spec.py
+++ b/src/e3/anod/spec.py
@@ -293,6 +293,14 @@ class Anod:
         pass
 
     @property
+    def args(self) -> dict[str, str | bool]:
+        """Access to final qualifier values (with defaults set)."""
+        if self.enable_name_generator:
+            return self.qualifiers_manager.qualifier_values
+        else:
+            return self.parsed_qualifier  # type: ignore
+
+    @property
     def base_name(self) -> str:
         """Set the base name used for the name generation.
 


### PR DESCRIPTION
- Allow "" as value for key-value qualifier
- Allow redefinition of components, build spaces and qualifiers (needed to use inheritance)
- Simplify logic for test_only qualifiers
- Set representation of key-value qualifier with "" value to "" when key is omited
- Adjust representation of key-value qualifier for default value
- Review test