### PR TITLE
Default to secure smtplib.SMTP_SSL when sending email

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 
 # Version 22.4.0 (2023-??-??) *NOT RELEASED YET*
 
-* Nothing
+* Security enhancements:
+  * e3.net.smtp.sendmail uses to ``SMTP_SSL`` by default
 
 # Version 22.3.1 (2023-03-17)
 

--- a/src/e3/net/smtp.py
+++ b/src/e3/net/smtp.py
@@ -74,7 +74,7 @@ def sendmail(
 
     smtp_class = (
         smtplib.SMTP_SSL
-        if "smtp_ssl" in os.environ.get("E3_ENABLE_FEATURE", "").split(",")
+        if "smtp_nossl" not in os.environ.get("E3_ENABLE_FEATURE", "").split(",")
         else smtplib.SMTP
     )
 


### PR DESCRIPTION
smtplib.SMTP is not secure enough enough, default to smtplib.SMTP_SSL and allow to switch back to the insecure mechanism when the E3_ENABLE_FEATURE environment variable contains smtp_nossl

TN: U510-022