### PR TITLE
Add .readthedocs.yaml (V2) configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+
+# Set the OS, Python version and other tools you might need.
+# OS can only be: ubuntu-20.04, ubuntu-22.04.
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+   install:
+   - requirements: docs/requirements.txt
+   - method: pip
+     path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
+sphinx==5.3.0
 sphinx-autoapi


### PR DESCRIPTION
We do not support the latest versions of sphinx (at least sphinx v7.2.5).

Currently, we have forced readthedoc to use the latest version of sphinx
known to work with e3-core: v5.3.0.