### PR TITLE
Handle star ending requirements in pypi add_constraint

### DIFF
--- a/src/e3/python/pypi.py
+++ b/src/e3/python/pypi.py
@@ -332,27 +332,34 @@ class Package:
 
         # Apply version constraints
         for spec in requirement.specs:
-            target_version = packaging.version.parse(spec[1])
-            if spec[0] == ">=":
-                self.versions = [v for v in self.versions if v >= target_version]
-            elif spec[0] == ">":
-                self.versions = [v for v in self.versions if v > target_version]
-            elif spec[0] == "!=":
-                self.versions = [v for v in self.versions if v != target_version]
-            elif spec[0] == "<":
-                self.versions = [v for v in self.versions if v < target_version]
-            elif spec[0] == "<=":
-                self.versions = [v for v in self.versions if v <= target_version]
-            elif spec[0] == "==":
-                self.versions = [v for v in self.versions if v == target_version]
-            elif spec[0] == "~=":
+            if spec[1].endswith(".*") and spec[0] == "!=":
+                # Handle requirements ending with * apart as it is not covered by
+                # packaging.version
                 self.versions = [
-                    v
-                    for v in self.versions
-                    if str(v).startswith(str(target_version) + ".")
+                    v for v in self.versions if not str(v).startswith(spec[1][:-2])
                 ]
             else:
-                raise PyPIError(f"Unknown constraint operator {spec[0]}")
+                target_version = packaging.version.parse(spec[1])
+                if spec[0] == ">=":
+                    self.versions = [v for v in self.versions if v >= target_version]
+                elif spec[0] == ">":
+                    self.versions = [v for v in self.versions if v > target_version]
+                elif spec[0] == "!=":
+                    self.versions = [v for v in self.versions if v != target_version]
+                elif spec[0] == "<":
+                    self.versions = [v for v in self.versions if v < target_version]
+                elif spec[0] == "<=":
+                    self.versions = [v for v in self.versions if v <= target_version]
+                elif spec[0] == "==":
+                    self.versions = [v for v in self.versions if v == target_version]
+                elif spec[0] == "~=":
+                    self.versions = [
+                        v
+                        for v in self.versions
+                        if str(v).startswith(str(target_version) + ".")
+                    ]
+                else:
+                    raise PyPIError(f"Unknown constraint operator {spec[0]}")
 
         if len(self.versions) != current_length:
             logging.debug(


### PR DESCRIPTION
Some packages like google-api-client can have requirements that discard all micro versions of a package for a given major and minor version. This is the case of the google-api-client package (v 2.97) which for example requires google-api-core!=2.1.*.