### PR TITLE
Fix doc build failure

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
-sphinx==5.3.0
-sphinx-autoapi
+sphinx==7.2.6
+sphinx-autoapi==3.0.0
+sphinx_rtd_theme==1.3.0


### PR DESCRIPTION
Last time, the doc build failed because rtd was not fully supported by Sphinx7. (See: [https://github.com/readthedocs/sphinx_rtd_theme/issues/1463](https://github.com/readthedocs/sphinx_rtd_theme/issues/1463))

This problem has now been corrected, so we want to use the latest rtd-compatible version of Sphinx.

Also fix the requirements version used in order to avoid future build failure.