### PR TITLE
git.py(git_cmd): always pass "-c" "fetch.prune=false" to git

### DIFF
--- a/src/e3/vcs/git.py
+++ b/src/e3/vcs/git.py
@@ -134,7 +134,7 @@ class GitRepository:
         if output == GIT_LOG_STREAM:
             output = self.log_stream
 
-        p_cmd = [arg for arg in cmd if arg is not None]
+        p_cmd = ["-c", "fetch.prune=false"] + [arg for arg in cmd if arg is not None]
         p_cmd.insert(0, self.__class__.git)
 
         p = e3.os.process.Run(p_cmd, cwd=self.working_tree, output=output, **kwargs)


### PR DESCRIPTION
Problem: Anod sometimes breaks because users set fetch.prune=true in
  their .gitconfig, which causes Git to remove references that are
  actually required by Anod during `git fetch`es.

Reproducer: Add the below snippet of code to your .gitconfig and run
  `anod update` twice.
  ```gitconfig
  [fetch]
    prune = true
  ```

Solution: Make every git command run with `-c fetch.prune=false`. This
  ensures that every git command will behave in an unsurprising way
  with regards to reference pruning on fetch. When pruning references on
  fetch is actually required, users of the `git_cmd` command will be
  able to add `--prune` to their `fetch` subcommand.
