### PR TITLE
Modify Trie code to avoid a mypy error

### DIFF
--- a/src/e3/collection/trie.py
+++ b/src/e3/collection/trie.py
@@ -100,8 +100,10 @@ class Trie:
             if self.END_MARKER in cursor and (not delimiter or letter in delimiter):
                 return True
             else:
-                cursor = cursor.get(letter, None)
-                if cursor is None:
+                new_cursor = cursor.get(letter, None)
+                if new_cursor is None:
                     return False
+                else:
+                    cursor = new_cursor
 
         return self.END_MARKER in cursor


### PR DESCRIPTION
cursor is a dict, cursor.get(.., None) returns another dict or None mypy is being confused as the variable is overwritten, use another temp variable to handle the case where letter is not in the cursor dict