### PR TITLE
use distro over ld

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ dependencies = [
   "psutil; sys_platform=='linux'",
   "psutil; sys_platform=='linux2'",
   "psutil; sys_platform=='darwin'",
-  "ld; sys_platform=='linux'",
-  "ld; sys_platform=='linux2'",
+  "distro; sys_platform=='linux'",
+  "distro; sys_platform=='linux2'",
 ]
 
 [project.urls]

--- a/src/e3/os/platform.py
+++ b/src/e3/os/platform.py
@@ -76,12 +76,12 @@ class SystemInfo:
 
         # Fetch linux distribution info on linux OS
         if cls.uname.system == "Linux":  # linux-only
-            import ld
+            import distro
 
             cls.ld_info = {
-                "name": ld.name(),
-                "major_version": ld.major_version(),
-                "version": ld.version(),
+                "name": distro.name(),
+                "major_version": distro.major_version(),
+                "version": distro.version(),
             }
 
         # Fetch core numbers. Note that the methods does not work


### PR DESCRIPTION
The `ld` package seems to have renamed itself to `distro`. I came about this while packaging for nixpkgs, and figured an upstream patch may be of some utility. Thanks so much!