### PR TITLE
Added a missing package class.

### DIFF
--- a/tests/coverage/base.rc
+++ b/tests/coverage/base.rc
@@ -9,6 +9,7 @@ omit =
 exclude_lines =
     all: no cover
     if TYPE_CHECKING:
+    @abstractmethod
     # os-specific
     defensive code
     assert_never()


### PR DESCRIPTION
The `PackageHomePage` class was missing from the available package information classed.

Some typos and warnings fixed too.

The `@abstractmethod` have been added to the coverage configuration since they may not be tested.