### PR TITLE
Fix e3-pypi-closure

### DIFF
--- a/src/e3/python/pypi.py
+++ b/src/e3/python/pypi.py
@@ -419,7 +419,7 @@ class PyPIClosure:
         :return: a Package object
         """
         # Normalize the package name
-        pkg = pkg.lower().replace("_", "-")
+        pkg = pkg.lower().replace("_", "-").replace(".", "-")
 
         pkg_extras = [""]
         if extras is not None:
@@ -463,7 +463,7 @@ class PyPIClosure:
         ) = base.split("-")
         project_name = project_name.lower().replace("_", "-")
 
-        pkg = project_name.lower().replace("_", "-")
+        pkg = project_name.replace(".", "-")
         logging.debug(f"Add metadata for {pkg}")
         self.db[pkg] = {
             "timestamp": time.time(),


### PR DESCRIPTION
When a package (such as ruamel) contained a dot in its name, the package retrieved by e3-pypi-closure might not be the one requested (for example when the version was set in the config file).

This patch is designed to prevent this.