### PR TITLE
Fix the SLSA build metadata tests

### DIFF
--- a/src/e3/slsa/provenance.py
+++ b/src/e3/slsa/provenance.py
@@ -386,9 +386,7 @@ class BuildMetadata(object):
         if isinstance(timestamp, datetime):
             # When converting to JSON representation, the microseconds
             # are lost. Just remove them.
-            valid_timestamp = timestamp.utcnow().replace(
-                microsecond=0, tzinfo=timezone.utc
-            )
+            valid_timestamp = timestamp.astimezone(timezone.utc).replace(microsecond=0)
         else:
             raise TypeError(f"Invalid timestamp type {type(timestamp)}")
 
@@ -866,7 +864,7 @@ class ResourceDescriptor(object):
         """Add a new digest to the digest set.
 
         :param algorithm: The algorithm the new digest has been computed with.
-        :param digest: The new digest to add to the diest set.
+        :param digest: The new digest to add to the digest set.
 
         :raise KeyError: if *algorithm* already defines a digest in the current
             digest set.
@@ -1378,7 +1376,7 @@ class Predicate(object):
             return self.__by_products
 
         @property
-        def metatdata(self) -> BuildMetadata:
+        def metadata(self) -> BuildMetadata:
             """Run details build metadata.
 
             Metadata about this particular execution of the build.
@@ -1395,7 +1393,7 @@ class Predicate(object):
             """  # noqa RST304
             return {
                 self.ATTR_BUILDER: self.builder.as_dict(),
-                self.ATTR_METADATA: self.metatdata.as_dict(),
+                self.ATTR_METADATA: self.metadata.as_dict(),
                 self.ATTR_BY_PRODUCTS: [rd.as_dict() for rd in self.by_products],
             }
 

--- a/tests/tests_e3/slsa/provenance_test.py
+++ b/tests/tests_e3/slsa/provenance_test.py
@@ -9,6 +9,7 @@ import pytest
 from datetime import datetime, timezone
 from dateutil import parser as date_parser
 from pathlib import Path
+from time import sleep
 from typing import Any
 
 from e3.slsa.provenance import (
@@ -33,6 +34,7 @@ INTERNAL_PARAMETERS: dict = {"internal": "parameters"}
 # find . -type f | cut -c3- | LC_ALL=C sort | xargs -r sha256sum \\
 #                       | sha256sum | cut -f1 -d' '
 
+# noinspection SpellCheckingInspection
 VALID_DIGESTS: dict[str, str] = {
     "blake2b": (
         "0a2293c1133aa5b2bdc84a0c8793db9cc60e8af7bb41acb661dc9c7264d35c8a0"
@@ -425,6 +427,10 @@ def test_predicate_load_json() -> None:
     bd: Predicate.BuildDefinition = create_valid_build_definition()[-1]
     rd: Predicate.RunDetails = create_valid_run_details()[-1]
     predicate: Predicate = Predicate(build_definition=bd, run_details=rd)
+    # Make sure the issue https://github.com/AdaCore/e3-core/issues/668 is
+    # fixed, add an (at least) one-second delay to make sure the timestamps are
+    # really copied from predicate, and not regenerated.
+    sleep(2.0)
     json_repr: str = predicate.as_json()
     # Create a second predicate with that dict representation.
     predicate2: Predicate = Predicate.load_json(json_repr)
@@ -433,7 +439,7 @@ def test_predicate_load_json() -> None:
     assert predicate.run_details == predicate2.run_details
 
 
-def test_resource_desciptor_add_digest() -> None:
+def test_resource_descriptor_add_digest() -> None:
     (
         uri,
         digest,
@@ -516,7 +522,7 @@ def test_resource_descriptor_digest() -> None:
     assert "Invalid resource descriptor digest" in invalid_digest.value.args[0]
 
 
-def test_resource_desciptor_dir_hash() -> None:
+def test_resource_descriptor_dir_hash() -> None:
     # Create a simple tree and try all algorithms on that tree.
     # The awaited checksum is the same as::
     #
@@ -663,7 +669,7 @@ def test_resource_descriptor_load_json() -> None:
 
 
 def test_resource_descriptor_media_type() -> None:
-    """Test setting a resource descriptor madiaType."""
+    """Test setting a resource descriptor mediaType."""
     desc = ResourceDescriptor()
     # Set a valid mediaType.
     desc.media_type = "media type"
@@ -758,7 +764,7 @@ def test_run_details_init() -> None:
     """Test the initialization of a predicate run details object."""
     builder, metadata, by_products, rd = create_valid_run_details()
     assert rd.builder == builder
-    assert rd.metatdata == metadata
+    assert rd.metadata == metadata
     assert rd.by_products == by_products
     # Test the __eq__ method with a wrong type.
     assert rd != {}
@@ -771,7 +777,7 @@ def test_run_details_load_dict() -> None:
     rd2: Predicate.RunDetails = Predicate.RunDetails.load_dict(dict_repr)
     # Check that all fields match.
     assert rd.builder == rd2.builder
-    assert rd.metatdata == rd2.metatdata
+    assert rd.metadata == rd2.metadata
     assert rd.by_products == rd2.by_products
 
     # Set an invalid metadata for the run details.
@@ -793,7 +799,7 @@ def test_run_details_load_json() -> None:
     rd2: Predicate.RunDetails = Predicate.RunDetails.load_json(rd.as_json())
     # Check that all fields match.
     assert rd.builder == rd2.builder
-    assert rd.metatdata == rd2.metatdata
+    assert rd.metadata == rd2.metadata
     assert rd.by_products == rd2.by_products
 
 


### PR DESCRIPTION
A SLSA predicate object contains run details, which itself contains some build metadata (start and end times).

A `BuildMetadata` class is thus initialized with two timestamps. Those timestamps are check and transformed to UTC timezone timestamps.

Unfortunately the timezone transformation was erasing the timestamp itself.

By using `datetime.astimezone()` method (and not `datetime.utcnow()` anymore), the test failure is fixed. To make sure this does not happen anymore, a time sleep has been added in some tests.

Fixes https://github.com/AdaCore/e3-core/issues/668