### PR TITLE
e3-pypi-closure: Add yanked management

### DIFF
--- a/src/e3/python/pypi.py
+++ b/src/e3/python/pypi.py
@@ -388,6 +388,10 @@ class PyPIClosure:
             data is cached a maximum of 24h. The cache contains results of requests to
             PyPI.
         :param pypi_url: set Python package registry URL. Default is PyPI
+        :param allowed_prerelease: list of package names authorized to be into
+            pre-release.
+        :param allowed_yanked: list of package names authorized to have yanked flags set
+            to true (see: PEP_592).
         """
         self.cache_file = cache_file
         self.cache_dir = cache_dir

--- a/src/e3/python/pypi.py
+++ b/src/e3/python/pypi.py
@@ -67,6 +67,11 @@ class PackageFile:
         return self.data["url"]
 
     @property
+    def is_yanked(self) -> bool:
+        """Return whether the package is yanked."""
+        return self.data.get("yanked", False)
+
+    @property
     def is_wheel(self) -> bool:
         """Return whether the package is a wheel."""
         return self.kind == "bdist_wheel"
@@ -191,6 +196,7 @@ class Package:
         for version in self.data.get("releases", {}):
             try:
                 v = packaging.version.parse(version)
+
                 if (not v.is_prerelease and not v.is_devrelease) or (
                     v.is_prerelease and self.name in pypi.allowed_prerelease
                 ):
@@ -236,9 +242,15 @@ class Package:
                 for f in all_files
                 if f.is_compatible_with_cpython3(self.pypi.python3_version)
                 and f.is_compatible_with_platforms(self.pypi.platforms)
+                and (not f.is_yanked or self.name in self.pypi.allowed_yanked)
             ]
             if any((f.is_generic_wheel for f in all_files)):
                 all_files = [f for f in all_files if f.is_wheel]
+
+            if not all_files:
+                self.versions.remove(packaging.version.parse(self.latest_version))
+                return self.latest_release
+
             self.releases[self.latest_version] = all_files
 
         return self.releases[self.latest_version]
@@ -365,6 +377,7 @@ class PyPIClosure:
         cache_file: str | None = None,
         pypi_url: str = "https://pypi.org/pypi",
         allowed_prerelease: list[str] | None = None,
+        allowed_yanked: list[str] | None = None,
     ) -> None:
         """Initialize a PyPI session.
 
@@ -385,6 +398,7 @@ class PyPIClosure:
         self.requirements: set[Requirement] = set()
         self.explicit_requirements: set[Requirement] = set()
         self.allowed_prerelease = allowed_prerelease or []
+        self.allowed_yanked = allowed_yanked or []
 
         self.platforms = platforms
         self.sys_platforms = set()

--- a/src/e3/python/pypiscript.py
+++ b/src/e3/python/pypiscript.py
@@ -88,6 +88,14 @@ def main() -> None:
         default=None,
         help="Allow to use pre-release version for some requirements",
     )
+    m.argument_parser.add_argument(
+        "--allow-yanked",
+        dest="allowed_yanked",
+        metavar="REQUIREMENT",
+        nargs="*",
+        default=None,
+        help="Allow to use yanked version for some requirements",
+    )
     m.parse_args()
     assert m.args is not None
 
@@ -162,6 +170,7 @@ def main() -> None:
         python3_version=m.args.python3_version,
         platforms=config["platforms"],
         allowed_prerelease=m.args.allowed_prerelease,
+        allowed_yanked=m.args.allowed_yanked,
     ) as pypi:
         for wheel in local_wheels:
             logging.info(f"Register wheel {wheel.path}")

--- a/src/e3/python/pypiscript.py
+++ b/src/e3/python/pypiscript.py
@@ -64,37 +64,40 @@ def main() -> None:
     m.argument_parser.description = DESCRIPTION.strip()
     m.argument_parser.add_argument("config_file", help="configuration files")
     m.argument_parser.add_argument(
-        "--python3-version", help="Python 3 version (default:10)", type=int, default=10
+        "--python3-version",
+        type=int,
+        default=10,
+        help="python 3 version (default: %(default)s)",
     )
     m.argument_parser.add_argument("target_dir", help="target directory")
     m.argument_parser.add_argument(
-        "--cache-dir", help="cache directory (default ./cache)", default="./cache"
+        "--cache-dir", help="cache directory (default: %(default)s)", default="./cache"
     )
     m.argument_parser.add_argument(
         "--skip-repo-updates",
         action="store_true",
-        help="Don't update clones in the cache",
+        help="don't update clones in the cache",
     )
     m.argument_parser.add_argument(
         "--local-clones",
-        help="Use local clones. When set look for git clones in a directory",
+        help="use local clones. When set look for git clones in a directory",
         default=None,
     )
     m.argument_parser.add_argument(
         "--allow-prerelease",
         dest="allowed_prerelease",
-        metavar="REQUIREMENT",
+        metavar="PACKAGE",
         nargs="*",
         default=None,
-        help="Allow to use pre-release version for some requirements",
+        help="allow to use pre-release version for some requirements",
     )
     m.argument_parser.add_argument(
         "--allow-yanked",
         dest="allowed_yanked",
-        metavar="REQUIREMENT",
+        metavar="PACKAGE",
         nargs="*",
         default=None,
-        help="Allow to use yanked version for some requirements",
+        help="allow to use yanked version for some requirements (See: PEP_592)",
     )
     m.parse_args()
     assert m.args is not None


### PR DESCRIPTION
As stated in PEP_592, a yanked package should not be installed unless it is the only one matching a version specifier.

It used to be possible for e3-pypi-closure to choose a yanked package, if it was simply the most recent version of the package.

With this patch, no yanked package will be installed without explicit use of the --allow-yanked option.

Also add minor improvement to e3-pypi-closure --help.