### PR TITLE
e3-pypi-closure: Normalize name with dot

### DIFF
--- a/src/e3/python/pypi.py
+++ b/src/e3/python/pypi.py
@@ -221,7 +221,7 @@ class Package:
     @property
     def name(self) -> str:
         """Name of the package."""
-        return self.data["info"]["name"]
+        return self.data["info"]["name"].replace(".", "-")
 
     @property
     def latest_release(self) -> list[PackageFile]:


### PR DESCRIPTION
This patch adds an oversight made in #665, to normalize the package name. This allows comparison between the package name and the name of its requirement.