### PR TITLE
Add secure_control_plane parameter in Machine entry points

### DIFF
--- a/src/e3/electrolyt/entry_point.py
+++ b/src/e3/electrolyt/entry_point.py
@@ -67,6 +67,7 @@ class Machine(EntryPoint):
         site: str | None = None,
         name: str | None = None,
         description: str | None = None,
+        secure_control_plane: bool = False,
     ):
         """Initialize a Machine entry point.
 
@@ -77,11 +78,15 @@ class Machine(EntryPoint):
         :param site: site indication
         :param name: see EntryPoint
         :param description: see EntryPoint
+        :param secure_control_plane: If true, this indicates the user requires
+            separation between the control plane and the build plane, which can
+            be implemented using containers.
         """
         super().__init__(db, fun, kind, name, description)
         self.platform = platform
         self.version = version
         self.site = site
+        self.secure_control_plane = secure_control_plane
 
 
 def entry_point(


### PR DESCRIPTION
Add the ability to indicate the need for the secure control plane in a Machine entry point.