### PR TITLE
Improve mock.os.process

### DIFF
--- a/src/e3/mock/os/process.py
+++ b/src/e3/mock/os/process.py
@@ -125,6 +125,12 @@ class MockRun(Run):
         :param config: MockRun configuration
         """
         self.config: MockRunConfig = copy.deepcopy(config) if config is not None else {}
+        self.call_count = 0
+
+    @property
+    def all_called(self) -> bool:
+        """Check all expected commands have been run."""
+        return not self.config.get("results", [])
 
     def add_result(self, result: CommandResult) -> None:
         """Queue a command result.
@@ -166,6 +172,7 @@ class MockRun(Run):
             self.status = result.status
             self.raw_out += result.raw_out
             self.raw_err += result.raw_err
+            self.call_count += 1
 
         return self
 

--- a/tests/tests_e3/mock/os/process/main_test.py
+++ b/tests/tests_e3/mock/os/process/main_test.py
@@ -62,6 +62,9 @@ def echo_world() -> None:
     """Run echo "world" with e3.os.process.Run."""
     echo("world")
 
+    assert e3.os.process.Run.all_called
+    assert e3.os.process.Run.call_count == 2
+
 
 @mock_run()
 def test_mock_run_decorator() -> None:
@@ -98,6 +101,8 @@ def test_mock_run_initial_add_result() -> None:
 
         # Run both commands
         echo_hello()
+        assert not e3.os.process.Run.all_called
+        assert e3.os.process.Run.call_count == 1
         echo_world()
 
 
@@ -109,6 +114,8 @@ def test_mock_run_sequential_add_result() -> None:
 
         # Run first command
         echo_hello()
+        assert e3.os.process.Run.all_called
+        assert e3.os.process.Run.call_count == 1
 
         # Add the result for second command
         e3.os.process.Run.add_result(ECHO_WORLD_RESULT)

--- a/tests/tests_e3/mock/os/process/main_test.py
+++ b/tests/tests_e3/mock/os/process/main_test.py
@@ -13,6 +13,8 @@ import e3.os.process
 from e3.mock.os.process import mock_run, CommandResult, MockRun, UnexpectedCommandError
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from e3.mock.os.process import MockRunConfig
 
 # Mock the result of echo "hello"
@@ -36,7 +38,7 @@ class SleepCommandResult(CommandResult):
         self.seconds = seconds
         super().__init__(["sleep", str(seconds)])
 
-    def __call__(self) -> None:
+    def __call__(self, *args: Any, **kwargs: Any) -> None:
         """Sleep x seconds."""
         time.sleep(self.seconds)
 


### PR DESCRIPTION
* Move logic to match the actual command with the expected one to CommandResult as this will allow to tweak the default filter depending on needs.
* Forward the actual command and arguments to `CommandResult.__call__` as this will allow to react to the actual command.
* Add `call_count` and `all_called` for tests.