### PR TITLE
Update e3-pypi-closure to generate more precise version

### DIFF
--- a/src/e3/python/pypiscript.py
+++ b/src/e3/python/pypiscript.py
@@ -5,7 +5,7 @@ from e3.anod.checkout import CheckoutManager
 from pkg_resources import Requirement
 from e3.main import Main
 from e3.fs import mkdir, cp
-from datetime import date
+from datetime import datetime
 import argparse
 import os
 import re
@@ -151,7 +151,7 @@ def main() -> None:
                 split_version = version.split(".")
                 if len(split_version) == 2:
                     # We have a major and minor but no patch so add it automatically
-                    version = f"{version}.{date.today().strftime('%Y%m%d')}"
+                    version = f"{version}.{datetime.today().strftime('%Y%m%d%H%M')}"
                     with open(version_file, "w") as fd:
                         fd.write(version)
 


### PR DESCRIPTION
Ensure that patch version generated when using
'update_wheel_version_file' option in a config file contains the time at which the package is generated. This ensures that several versions of the same package can be generated during a given day