### PR TITLE
e3.sys: Replace pkg_resources by importlib.metadata

### DIFF
--- a/src/e3/sys.py
+++ b/src/e3/sys.py
@@ -125,9 +125,9 @@ class RewriteImportNodeTransformer(ast.NodeTransformer):
 
 
 def version() -> str:
-    import pkg_resources
+    import importlib.metadata
 
-    return pkg_resources.get_distribution("e3-core").version
+    return importlib.metadata.version("e3-core")
 
 
 def sanity_check() -> int:


### PR DESCRIPTION
pkg_resources is deprecated causing warning on our testsuite.

See: https://setuptools.pypa.io/en/latest/pkg_resources.html
