### PR TITLE
Fix pytest error

### DIFF
--- a/src/e3/main.py
+++ b/src/e3/main.py
@@ -31,6 +31,7 @@ import logging
 import os
 import signal
 import sys
+import threading
 
 from typing import TYPE_CHECKING
 
@@ -144,7 +145,9 @@ class Main:
             raise SystemExit("SIGTERM received")
 
         if sys.platform != "win32":  # unix-only
-            signal.signal(signal.SIGTERM, sigterm_handler)
+            if threading.current_thread() is threading.main_thread():
+                # Signal can only be used in the main thread
+                signal.signal(signal.SIGTERM, sigterm_handler)
 
     def parse_args(
         self,


### PR DESCRIPTION
When pytest is used with xdist and junitxml, tests are not run in the main thread. In addition, signals can only be used in the main thread.

This results in the failure of some tests that attempt to define a signal handler.

The signal handler causing the error is not tested, so we simply disable the handler if the current thread is not the main thread.