### PR TITLE
E3 pypi closure

### DIFF
--- a/src/e3/python/pypi.py
+++ b/src/e3/python/pypi.py
@@ -203,7 +203,10 @@ class Package:
                 ):
                     self.versions.append(v)
             except Exception:
-                logger.warning(f"Cannot parse version {version} of {self.name}")
+                # Many packages uploaded before pip 1.4 had versions that are
+                # rejected by packaging.version. Do not warn but just log
+                # the error.
+                logger.debug(f"Cannot parse version {version} of {self.name}")
         logger.debug(f"Load package {self.name}")
 
     def __eq__(self, other: Any) -> bool:

--- a/src/e3/python/pypi.py
+++ b/src/e3/python/pypi.py
@@ -182,7 +182,7 @@ class Package:
         *,
         data: dict["str", Any],
     ) -> None:
-        """Initialize a pakage metadata object.
+        """Initialize a package metadata object.
 
         :param pypi: a PyPIClosure session
         :param data: the data as fetched on pypi


### PR DESCRIPTION
Silence "cannot parse version" warning by default
    
This message occurs way too often when running e3-pypi-closure
because of bad version in old software.
