### PR TITLE
Detect cycles during DAG iteration when "enable_busy_state" is set

### DIFF
--- a/src/e3/collection/dag.py
+++ b/src/e3/collection/dag.py
@@ -75,19 +75,18 @@ class DAGIterator:
         result = next((k for k in self.non_visited if self.pred_number[k] == 0), None)
 
         if result is None:
+            for node in self.non_visited:
+                minimal_cycle = self.dag.shortest_path(node, node)
+                if minimal_cycle is not None:
+                    raise DAGError(
+                        "cycle detected: %s"
+                        % " -> ".join([str(vertex_id) for vertex_id in minimal_cycle])
+                    )
+
             if not self.enable_busy_state:
-                for node in self.non_visited:
-                    minimal_cycle = self.dag.shortest_path(node, node)
-                    if minimal_cycle is not None:
-                        raise DAGError(
-                            "cycle detected: %s"
-                            % " -> ".join(
-                                [str(vertex_id) for vertex_id in minimal_cycle]
-                            )
-                        )
                 raise DAGError("cycle detected (unknown error)")
 
-            # No vertex is ready to be visited
+            # Wait for busy vertices to finish
             return None, None, frozenset()
 
         # Remove the vertex from the "non_visited_list" and when

--- a/tests/tests_e3/collection/dag/main_test.py
+++ b/tests/tests_e3/collection/dag/main_test.py
@@ -87,6 +87,14 @@ def test_cycle_detection():
     with pytest.raises(DAGError):
         d.check()
 
+    with pytest.raises(DAGError):
+        it = DAGIterator(d)
+        [k for k, _ in it]
+
+    with pytest.raises(DAGError):
+        it = DAGIterator(d, enable_busy_state=True)
+        [k for k, _ in it]
+
     # Verify that some functions do not hang when a cycle is present
     assert len(d.get_closure("b")) == 2
     assert str(d)


### PR DESCRIPTION
When "enable_busy_state" is set, iterate over the DAG made all non-visited nodes wait for predecessors as if the latter were in the busy state.

Cycles are now always checked, no matter the enable_busy_state value.

Fix issue #717