### PR TITLE
Fix pip error

### DIFF
--- a/src/e3/python/wheel.py
+++ b/src/e3/python/wheel.py
@@ -58,6 +58,7 @@ class Wheel:
                     "wheel",
                     ".",
                     "-q",
+                    "--no-build-isolation",
                     "--no-deps",
                     f"-C--python-tag={python_tag}",
                     "-w",


### PR DESCRIPTION
pip fails in production because it cannot find setuptools (which is installed) and tries to connect it to pypi.

We add the --no-build-isolation option to allow pip to use the setuptools installed in our python.