### PR TITLE
Fix action statement for affected products

### DIFF
--- a/src/e3/encoding/vex.py
+++ b/src/e3/encoding/vex.py
@@ -882,9 +882,9 @@ class StatementStatus(JsonData):
                     f"When status is {self.status.value}, either an impact "
                     "statement or a justification must be provided."
                 )
-        elif self.status == ProductStatus.AFFECTED and not self.impact:
+        elif self.status == ProductStatus.AFFECTED and not self.action:
             raise ValueError(
-                f"When status is {self.status.value}, an impact statement "
+                f"When status is {self.status.value}, an action statement "
                 "must be provided."
             )
 

--- a/tests/tests_e3/encoding/vex_test.py
+++ b/tests/tests_e3/encoding/vex_test.py
@@ -114,10 +114,10 @@ STATEMENT_STATUS_PARAMETERS = [
     (
         ProductStatus.AFFECTED,
         None,
-        "Action to take",
+        None,
         None,
         "notes",
-        "an impact statement must be provided",
+        "an action statement must be provided",
     ),
 ]
 


### PR DESCRIPTION
As per paragraph _2.7.1.2.1_ of
[Minimum Requirements for Vulnerability Exploitability eXchange (VEX)](https://www.cisa.gov/sites/default/files/2023-04/minimum-requirements-for-vex-508c.pdf), the affected products **MUST** have an action statement.

Both the spec implementation and the tests were wrong on that point, and were expecting an **impact** statement instead.

The behaviour should now be correct regarding that.