### PR TITLE
Add a shared libraries closure check to anod spec

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # Version 22.7.0 (2024-??-??) *NOT RELEASED YET*
+* Add DLL closure check to Anod class
 
 * Add git_shallow_fetch_since to checkout.py
 

--- a/tests/tests_e3/conftest.py
+++ b/tests/tests_e3/conftest.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 from e3.pytest import require_tool
 
 git = require_tool("git")
+ldd = require_tool("ldd")
 svn = require_tool("svn")
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ extras =
       check
 commands =
 # Accept yaml.load(), pickle, and exec since this
-# is needed by e3. Also temporarly accept sha1 usage until this is replaced by
+# is needed by e3. Also temporarily accept sha1 usage until this is replaced by
 # more secure alternative. There is also e3.env.tmp_dir that returns the TMPDIR
 # environment variable. Don't check for that.
 # B202: should be investigated see https://github.com/AdaCore/e3-core/issues/694
@@ -46,7 +46,10 @@ commands =
 
 [flake8]
 exclude = .git,__pycache__,build,dist,.tox
-ignore = A003, C901, E203, E266, E501, W503,D100,D101,D102,D102,D103,D104,D105,D106,D107,D203,D403,D213,B028,B906,B907,E704
+# Ignored:
+#   A005: the module is shadowing a Python builtin module. We have many modules
+#         doing that (logging, json ...)
+ignore = A003, A005, C901, E203, E266, E501, W503,D100,D101,D102,D102,D103,D104,D105,D106,D107,D203,D403,D213,B028,B906,B907,E704
 # line length is intentionally set to 80 here because black uses Bugbear
 # See https://github.com/psf/black/blob/master/README.md#line-length for more details
 max-line-length = 80


### PR DESCRIPTION
The `check_shared_libraries_closure()` methods allows to make sure the
shared library of a spec only link with valid shared libraries.

For instance, when linking with our own version of `zlib`, we want
to make sure that the built shared libraries do not link with
`/usr/lib/libz.so`, but with our `zlib`.