### PR TITLE
Use at least --shallow-since when git_shallow_fetch is enabled

### DIFF
--- a/src/e3/anod/checkout.py
+++ b/src/e3/anod/checkout.py
@@ -242,16 +242,21 @@ class CheckoutManager:
 
         try:
             old_commit = g.rev_parse()
-
+            shallow_cmd: str | None = None
             # Using fetch + checkout ensure caching is effective
             shallow = "git_shallow_fetch" in os.environ.get(
                 "E3_ENABLE_FEATURE", ""
-            ).split(",") and (not self.compute_changelog or not old_commit)
+            ).split(",")
+            if shallow and (not self.compute_changelog or not old_commit):
+                shallow_cmd = "--depth=1"
+            else:
+                shallow_cmd = f"--shallow-since={old_commit}"
+
             g.git_cmd(
                 [
                     "fetch",
                     "-f",
-                    "--depth=1" if shallow else None,
+                    shallow_cmd,
                     remote_name,
                     f"{revision}:refs/e3-checkout",
                 ]


### PR DESCRIPTION
When git_shallow_fetch feature is requested, even when we need to compute a changelog, we should not fetch the full depth of the repository. Just fetch at the required depth instead.